### PR TITLE
change(macos-release): When nvim-osx64 folder is found it will be renamed to nvim-macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,26 +150,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.14"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535434c063ced786eb04aaf529308092c5ab60889e8fe24275d15de07b01fa97"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -180,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -728,9 +726,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl"
@@ -844,11 +842,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1199,12 +1197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1423,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "4.0.15", features = ["derive"] }
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bob"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/modules/cli.rs
+++ b/src/modules/cli.rs
@@ -11,20 +11,20 @@ enum Cli {
     /// Switch to the specified version, will auto-invoke install command
     /// if the version is not installed already
     Use {
-        /// Version to switch to
+        /// Version to switch to |nightly|stable|<version-string>|
         version: String,
     },
 
     /// Install the specified version, can also be used to update
     /// out-of-date nightly version
     Install {
-        /// Version to be installed
+        /// Version to be installed |nightly|stable|<version-string>|
         version: String,
     },
 
     /// Uninstall the specified version
     Uninstall {
-        /// Version to be uninstalled
+        /// Version to be uninstalled |nightly|stable|<version-string>|
         version: String,
     },
 

--- a/src/modules/cli.rs
+++ b/src/modules/cli.rs
@@ -1,12 +1,12 @@
 use super::{erase_handler, install_handler, ls_handler, uninstall_handler, use_handler, utils};
 use crate::{enums::InstallResult, models::Config};
 use anyhow::Result;
-use clap::{AppSettings, Parser};
+use clap::Parser;
 use reqwest::Client;
 use tracing::info;
 
 #[derive(Debug, Parser)]
-#[clap(global_setting = AppSettings::DeriveDisplayOrder)]
+#[command(version)]
 enum Cli {
     /// Switch to the specified version, will auto-invoke install command
     /// if the version is not installed already

--- a/src/modules/expand_archive.rs
+++ b/src/modules/expand_archive.rs
@@ -87,6 +87,8 @@ fn expand(downloaded_file: DownloadedVersion) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     use tar::Archive;
 
+    use crate::modules::utils;
+
     if fs::metadata(&downloaded_file.file_name).is_ok() {
         fs::remove_dir_all(&downloaded_file.file_name)?;
     }
@@ -138,11 +140,10 @@ fn expand(downloaded_file: DownloadedVersion) -> Result<()> {
         "Finished expanding to {}/{}",
         downloaded_file.path, downloaded_file.file_name
     ));
-    let platform = if cfg!(target_os = "macos") {
-        "nvim-osx64"
-    } else {
-        "nvim-linux64"
-    };
+    if fs::metadata(format!("{}/nvim-osx64", downloaded_file.file_name)).is_ok() {
+        fs::rename(format!("{}/nvim-osx64", downloaded_file.file_name), "nvim-macos")?;
+    }
+    let platform = utils::get_platform_name();
     let file = &format!("{}/{platform}/bin/nvim", downloaded_file.file_name);
     let mut perms = fs::metadata(file)?.permissions();
     perms.set_mode(0o111);

--- a/src/modules/use_handler.rs
+++ b/src/modules/use_handler.rs
@@ -65,11 +65,7 @@ async fn link_version(version: &str, config: &Config) -> Result<()> {
             }
         } else {
             use std::os::unix::fs::symlink;
-            let folder_name = if cfg!(target_os = "macos") {
-                "nvim-osx64"
-            } else {
-                "nvim-linux64"
-            };
+            let folder_name = utils::get_platform_name();
             if let Err(error) = symlink(format!("{base_path}/{folder_name}"), &installation_dir) {
                 return Err(anyhow!(error))
             }

--- a/src/modules/use_handler.rs
+++ b/src/modules/use_handler.rs
@@ -65,6 +65,9 @@ async fn link_version(version: &str, config: &Config) -> Result<()> {
             }
         } else {
             use std::os::unix::fs::symlink;
+            if fs::metadata(format!("{base_path}/nvim-osx64")).await.is_ok() {
+                fs::rename(format!("{base_path}/nvim-osx64"), "nvim-macos").await?;
+            }
             let folder_name = utils::get_platform_name();
             if let Err(error) = symlink(format!("{base_path}/{folder_name}"), &installation_dir) {
                 return Err(anyhow!(error))


### PR DESCRIPTION
fix #54 