### PR TITLE
add check for empty installations, add alias for `uninstall`

### DIFF
--- a/src/modules/cli.rs
+++ b/src/modules/cli.rs
@@ -23,6 +23,7 @@ enum Cli {
     },
 
     /// Uninstall the specified version
+    #[clap(visible_alias = "rm")]
     Uninstall {
         /// Version to be uninstalled |nightly|stable|<version-string>|<commit-hash>|
         version: String,

--- a/src/modules/expand_archive.rs
+++ b/src/modules/expand_archive.rs
@@ -47,7 +47,7 @@ fn expand(downloaded_file: LocalVersion) -> Result<()> {
 
     let pb = ProgressBar::new(totalsize);
     pb.set_style(ProgressStyle::default_bar()
-        .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos:>7}/{len:>7}")
+        .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len}")
         .progress_chars("█  "));
     pb.set_message("Expanding archive");
 
@@ -107,7 +107,7 @@ fn expand(downloaded_file: LocalVersion) -> Result<()> {
     let totalsize = 1692; // hard coding this is pretty unwise, but you cant get the length of an archive in tar-rs unlike zip-rs
     let pb = ProgressBar::new(totalsize);
     pb.set_style(ProgressStyle::default_bar()
-        .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos:>7}/{len:>7}")
+        .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len}")
         .progress_chars("█  "));
     pb.set_message("Expanding archive");
 

--- a/src/modules/ls_handler.rs
+++ b/src/modules/ls_handler.rs
@@ -3,6 +3,7 @@ use crate::models::Config;
 use super::utils;
 use anyhow::{anyhow, Result};
 use yansi::Paint;
+use tracing::info;
 
 pub async fn start(config: Config) -> Result<()> {
     let downloads_dir = match utils::get_downloads_folder(&config).await {
@@ -10,8 +11,13 @@ pub async fn start(config: Config) -> Result<()> {
         Err(error) => return Err(anyhow!(error)),
     };
 
-    let paths = std::fs::read_dir(downloads_dir)?;
+    let mut paths = std::fs::read_dir(downloads_dir)?;
     const VERSION_MAX_LEN: usize = 7;
+
+    if !&paths.next().is_some() {
+        info!("There are no versions installed");
+        return Ok(());
+    }
 
     println!("Version | Status");
     println!("{}+{}", "-".repeat(7 + 1), "-".repeat(10));


### PR DESCRIPTION
- check for empty installation.
- alias `rm` for the `uninstall` subcommand.
- removed padding for progress on unzipping.