### PR TITLE
refactor: improve error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ async fn main() -> Result<()> {
 }
 
 async fn run() -> Result<()> {
-    let config_dir = dirs::config_dir().unwrap();
-    let config_file = format!("{}/bob/config.json", config_dir.to_str().unwrap());
+    let config_dir = dirs::config_dir().ok_or_else(|| anyhow!("config directory not found"))?;
+    let config_file = config_dir.join("bob").join("config.json");
     let config: Config = match tokio::fs::read_to_string(config_file).await {
         Ok(config_file) => serde_json::from_str(&config_file)?,
         Err(_) => Config {

--- a/src/modules/expand_archive.rs
+++ b/src/modules/expand_archive.rs
@@ -9,11 +9,9 @@ use crate::models::LocalVersion;
 
 pub async fn start(file: LocalVersion) -> Result<()> {
     let temp_file = file.clone();
-    match tokio::task::spawn_blocking(move || {
-        match expand(temp_file) {
-            Ok(_) => Ok(()),
-            Err(error) => Err(anyhow!(error)),
-        }
+    match tokio::task::spawn_blocking(move || match expand(temp_file) {
+        Ok(_) => Ok(()),
+        Err(error) => Err(anyhow!(error)),
     })
     .await
     {

--- a/src/modules/install_handler.rs
+++ b/src/modules/install_handler.rs
@@ -27,7 +27,7 @@ pub async fn start(
     env::set_current_dir(&root)?;
     let root = root.as_path();
 
-    let is_version_installed = utils::is_version_installed(&version.tag_name, config).await;
+    let is_version_installed = utils::is_version_installed(&version.tag_name, config).await?;
 
     let nightly_version = if version.tag_name == "nightly" {
         let upstream_nightly = match utils::get_upstream_nightly(client).await {
@@ -40,9 +40,9 @@ pub async fn start(
 
             match config.enable_nightly_info {
                 Some(boolean) if boolean => {
-                    print_commits(client, &local_nightly, &upstream_nightly).await
+                    print_commits(client, &local_nightly, &upstream_nightly).await?
                 }
-                None => print_commits(client, &local_nightly, &upstream_nightly).await,
+                None => print_commits(client, &local_nightly, &upstream_nightly).await?,
                 _ => (),
             }
 
@@ -86,11 +86,13 @@ pub async fn start(
     ))
 }
 
-async fn print_commits(client: &Client, local: &UpstreamVersion, upstream: &UpstreamVersion) {
+async fn print_commits(
+    client: &Client,
+    local: &UpstreamVersion,
+    upstream: &UpstreamVersion,
+) -> Result<()> {
     let commits =
-        utils::get_commits_for_nightly(client, &local.published_at, &upstream.published_at)
-            .await
-            .unwrap();
+        utils::get_commits_for_nightly(client, &local.published_at, &upstream.published_at).await?;
 
     for commit in commits {
         println!(
@@ -99,6 +101,8 @@ async fn print_commits(client: &Client, local: &UpstreamVersion, upstream: &Upst
             commit.commit.message.replace('\n', "\n| ")
         );
     }
+
+    Ok(())
 }
 
 async fn download_version(


### PR DESCRIPTION
This PR updates codebase to utilize `anyhow` to avoid panicking via `unwrap()` and handles the errors gracefully.

