### PR TITLE
refactor: apply clippy suggestions

### DIFF
--- a/src/modules/ls_handler.rs
+++ b/src/modules/ls_handler.rs
@@ -20,7 +20,7 @@ pub async fn start(config: Config) -> Result<()> {
         .collect::<Vec<_>>();
     const VERSION_MAX_LEN: usize = 7;
 
-    if paths.len() == 0 {
+    if paths.is_empty() {
         return Err(anyhow!("There are no versions installed"));
     }
 

--- a/src/modules/use_handler.rs
+++ b/src/modules/use_handler.rs
@@ -32,9 +32,7 @@ pub async fn start(version: InputVersion, client: &Client, config: Config) -> Re
         crate::enums::VersionType::Hash => &version.tag_name[0..7],
     };
 
-    if let Err(error) = link_version(version_link, &config, is_version_used).await {
-        return Err(error);
-    }
+    link_version(version_link, &config, is_version_used).await?;
     fs::write("used", &version.tag_name).await?;
     info!("You can now use {}!", version.tag_name);
 
@@ -42,7 +40,7 @@ pub async fn start(version: InputVersion, client: &Client, config: Config) -> Re
 }
 
 async fn link_version(version: &str, config: &Config, is_version_used: bool) -> Result<()> {
-    let installation_dir = match utils::get_installation_folder(&config) {
+    let installation_dir = match utils::get_installation_folder(config) {
         Err(_) => return Err(anyhow!("Couldn't get data dir")),
         Ok(value) => value,
     };


### PR DESCRIPTION
This commit fixes the lints suggested by rust-clippy.

<details>
<summary>Details</summary>

```
error: written amount is not handled
   --> src/modules/install_handler.rs:140:29
    |
140 | ...                   file.write(&chunk).await?;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `AsyncWriteExt::write_all` instead, or handle partial writes
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
    = note: `#[deny(clippy::unused_io_amount)]` on by default

warning: match expression looks like `matches!` macro
   --> src/modules/install_handler.rs:182:31
    |
182 |                   Err(error) => match error.kind() {
    |  _______________________________^
183 | |                     std::io::ErrorKind::NotFound => false,
184 | |                     _ => true,
185 | |                 },
    | |_________________^ help: try this: `!matches!(error.kind(), std::io::ErrorKind::NotFound)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
    = note: `#[warn(clippy::match_like_matches_macro)]` on by default

warning: match expression looks like `matches!` macro
   --> src/modules/install_handler.rs:189:31
    |
189 |                   Err(error) => match error.kind() {
    |  _______________________________^
190 | |                     std::io::ErrorKind::NotFound => false,
191 | |                     _ => true,
192 | |                 },
    | |_________________^ help: try this: `!matches!(error.kind(), std::io::ErrorKind::NotFound)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

warning: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> src/modules/install_handler.rs:205:23
    |
205 |           Err(error) => match error.kind() {
    |  _______________________^
206 | |             std::io::ErrorKind::NotFound => {
207 | |                 return Err(anyhow!(
208 | |                     "Cmake has to be installed in order to build neovim from source"
...   |
211 | |             _ => (),
212 | |         },
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
    = note: `#[warn(clippy::single_match)]` on by default
help: try this
    |
205 ~         Err(error) => if error.kind() == std::io::ErrorKind::NotFound {
206 +             return Err(anyhow!(
207 +                 "Cmake has to be installed in order to build neovim from source"
208 +             ))
209 ~         },
    |

warning: length comparison to zero
  --> src/modules/ls_handler.rs:23:8
   |
23 |     if paths.len() == 0 {
   |        ^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `paths.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
   = note: `#[warn(clippy::len_zero)]` on by default

warning: this block may be rewritten with the `?` operator
  --> src/modules/use_handler.rs:35:5
   |
35 | /     if let Err(error) = link_version(version_link, &config, is_version_used).await {
36 | |         return Err(error);
37 | |     }
   | |_____^ help: replace it with: `link_version(version_link, &config, is_version_used).await?;`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
   = note: `#[warn(clippy::question_mark)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/modules/use_handler.rs:45:65
   |
45 |     let installation_dir = match utils::get_installation_folder(&config) {
   |                                                                 ^^^^^^^ help: change this to: `config`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: unnecessary `if let` since only the `Ok` variant of the iterator element is used
   --> src/modules/utils.rs:109:5
    |
109 |       for entry in read_dir {
    |       ^            -------- help: try: `read_dir.flatten()`
    |  _____|
    | |
110 | |         if let Ok(entry) = entry {
111 | |             let path = entry.path();
112 | |
...   |
122 | |         }
123 | |     }
    | |_____^
    |
help: ...and remove the `if let` statement in the for loop
   --> src/modules/utils.rs:110:9
    |
110 | /         if let Ok(entry) = entry {
111 | |             let path = entry.path();
112 | |
113 | |             if path.is_dir() {
...   |
121 | |             pb.set_position(removed);
122 | |         }
    | |_________^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten
    = note: `#[warn(clippy::manual_flatten)]` on by default

warning: deref which would be done by auto-deref
   --> src/modules/utils.rs:197:42
    |
197 |     let output = String::from_utf8_lossy(&*output.stdout).to_string();
    |                                          ^^^^^^^^^^^^^^^ help: try this: `&output.stdout`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default

warning: `bob` (bin "bob") generated 8 warnings
error: could not compile `bob` due to previous error; 8 warnings emitted
```

</details>
