### PR TITLE
chore(ci): integrate clippy to continuous integration workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           command: build
           args: --profile optimized
+      - name: Check lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose -- -D warnings
       - name: Upload Bob Linux binary
         uses: actions/upload-artifact@v2
         with:
@@ -43,6 +48,11 @@ jobs:
         with:
           command: build
           args: --profile optimized
+      - name: Check lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose -- -D warnings
       - name: Upload Bob MacOS binary
         uses: actions/upload-artifact@v2
         with:
@@ -67,6 +77,11 @@ jobs:
         with:
           command: build
           args: --profile optimized
+      - name: Check lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose -- -D warnings
       - name: Setup Bob build directory
         run: |
           mkdir build

--- a/src/modules/install_handler.rs
+++ b/src/modules/install_handler.rs
@@ -136,7 +136,7 @@ async fn download_version(
                         let mut downloaded: u64 = 0;
 
                         while let Some(item) = response_bytes.next().await {
-                            let chunk = item.or(Err(anyhow!("hello")))?;
+                            let chunk = item.map_err(|_| anyhow!("hello"))?;
                             file.write_all(&chunk).await?;
                             let new = min(downloaded + (chunk.len() as u64), total_size);
                             downloaded = new;
@@ -172,7 +172,7 @@ async fn handle_building_from_source(
 ) -> Result<PostDownloadVersionType> {
     cfg_if::cfg_if! {
         if #[cfg(windows)] {
-            if let Err(_) = env::var("VisualStudioVersion") {
+            if env::var("VisualStudioVersion").is_err() {
                 return Err(anyhow!("Please make sure you are using Developer PowerShell/Command Prompt for VS"));
             }
 

--- a/src/modules/utils.rs
+++ b/src/modules/utils.rs
@@ -73,11 +73,10 @@ pub async fn get_downloads_folder(config: &Config) -> Result<PathBuf> {
                 home_dir.push(".local/share");
                 home_dir
             } else {
-                let data_dir = match data_local_dir() {
+                match data_local_dir() {
                     None => return Err(anyhow!("Couldn't get local data folder")),
                     Some(value) => value,
-                };
-                data_dir
+                }
             };
 
             data_dir.push("bob");
@@ -199,7 +198,7 @@ pub async fn get_current_version(config: &Config) -> Result<String> {
     let regex = Regex::new(r"v[0-9]\.[0-9]\.[0-9]")?;
     Ok(regex.find(output.as_str()).unwrap().as_str().to_owned())
             },
-            _ => return Err(anyhow!("{} is corrupted, try running bob use again or open an issue at https://github.com/MordechaiHadad/bob", downloads_dir.display())),
+            _ => Err(anyhow!("{} is corrupted, try running bob use again or open an issue at https://github.com/MordechaiHadad/bob", downloads_dir.display())),
         },
     }
 }


### PR DESCRIPTION
This PR integrates `clippy` to CI workflow for checking lints so that issues like #71 can be detected early in the development phase.

