### PR TITLE
chore(cargo): add metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "bob"
 version = "1.2.0"
+description = "A version manager for neovim"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/MordechaiHadad/bob"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "4.0.15", features = ["derive"] }


### PR DESCRIPTION
I saw that some information is missing in `Cargo.toml` so I decided to add them via this PR. (They are useful for crates.io release)
