### PR TITLE
Feature: bob sync (and `sync_version_file_path` config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Install the specified version, can also be used to update out-of-date nightly ve
 
 ---
 
+- `bob sync`
+
+If Config::sync_version_file_path is set, the version in that file will be parsed and installed.
+
+---
+
 - `bob uninstall |nightly|stable|<version-string>|<commit-hash>|`
 
 Uninstall the specified version.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ Bob's configuration file will have to be in `config_dir/bob/config.json`, to be 
 {
   "enable_nightly_info": true, // Will show new commits associated with new nightly release if enabled
   "downloads_dir": "/home/user/.local/share/bob/", // The folder in which neovim versions will be installed too, bob will error if this option is specified but the folder doesn't exist
-  "installation_location": "/home/user/.local/share/neovim" // The path in which the used neovim version will be located in
+  "installation_location": "/home/user/.local/share/neovim", // The path in which the used neovim version will be located in
+  "sync_version_file_path": "/home/user/.config/nvim/nvim.version", // The path to a file that will hold the neovim version string, useful for config version tracking, bob will error if the specified file is not a valid file path
 }
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn handle_config(config_file: Result<String, std::io::Error>) -> Result<Config> 
             enable_nightly_info: None,
             downloads_dir: None,
             installation_location: None,
+            sync_version_file_path: None,
         },
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,13 @@ fn handle_envars(config: &mut Config) -> Result<()> {
         }
     }
 
+    if let Some(value) = &config.sync_version_file_path {
+        if re.is_match(value) {
+            let new_value = handle_envar(value, &re)?;
+            config.sync_version_file_path = Some(new_value);
+        }
+    }
+
     Ok(())
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -35,6 +35,7 @@ pub struct Config {
     pub enable_nightly_info: Option<bool>,
     pub downloads_dir: Option<String>,
     pub installation_location: Option<String>,
+    pub sync_version_file_path: Option<String>,
 }
 
 pub struct InputVersion {

--- a/src/modules/cli.rs
+++ b/src/modules/cli.rs
@@ -1,4 +1,6 @@
-use super::{erase_handler, install_handler, ls_handler, uninstall_handler, use_handler, utils};
+use super::{
+    erase_handler, install_handler, ls_handler, sync_handler, uninstall_handler, use_handler, utils,
+};
 use crate::{enums::InstallResult, models::Config};
 use anyhow::Result;
 use clap::Parser;
@@ -21,6 +23,10 @@ enum Cli {
         /// Version to be installed |nightly|stable|<version-string>|<commit-hash>|
         version: String,
     },
+
+    /// If Config::sync_version_file_path is set, the version in that file
+    /// will be parsed and installed
+    Sync,
 
     /// Uninstall the specified version
     #[clap(visible_alias = "rm")]
@@ -66,6 +72,11 @@ pub async fn start(config: Config) -> Result<()> {
                     info!("Nightly up to date!");
                 }
             }
+        }
+        Cli::Sync => {
+            let client = Client::new();
+            info!("Starting sync process");
+            sync_handler::start(&client, config).await?;
         }
         Cli::Uninstall { version } => {
             info!("Starting uninstallation process");

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,6 +3,7 @@ pub mod erase_handler;
 mod expand_archive;
 pub mod install_handler;
 pub mod ls_handler;
+pub mod sync_handler;
 pub mod uninstall_handler;
 pub mod use_handler;
 pub mod utils;

--- a/src/modules/sync_handler.rs
+++ b/src/modules/sync_handler.rs
@@ -1,0 +1,33 @@
+use super::utils;
+use crate::models::Config;
+use anyhow::{anyhow, Result};
+use reqwest::Client;
+use tokio::fs;
+use tracing::info;
+
+use super::use_handler;
+
+pub async fn start(client: &Client, config: Config) -> Result<()> {
+    if let Some(sync_version_file_path) = utils::get_sync_version_file_path(&config).await? {
+        let version = fs::read_to_string(&sync_version_file_path).await?;
+        info!(
+            "Using version {version} set in {}",
+            sync_version_file_path
+                .into_os_string()
+                .into_string()
+                .unwrap()
+        );
+        use_handler::start(
+            utils::parse_version_type(client, &version).await?,
+            client,
+            config,
+        )
+        .await?;
+    } else {
+        return Err(anyhow!(
+            "sync_version_file_path needs to be set to use `bob sync`"
+        ));
+    }
+
+    Ok(())
+}

--- a/src/modules/use_handler.rs
+++ b/src/modules/use_handler.rs
@@ -35,14 +35,18 @@ pub async fn start(version: InputVersion, client: &Client, config: Config) -> Re
     link_version(version_link, &config, is_version_used).await?;
     fs::write("used", &version.tag_name).await?;
     if let Some(sync_version_file_path) = utils::get_sync_version_file_path(&config).await? {
-        fs::write(&sync_version_file_path, &version.tag_name).await?;
-        info!(
-            "Written version to {}",
-            sync_version_file_path
-                .into_os_string()
-                .into_string()
-                .unwrap()
-        );
+        // Write the used version to sync_version_file_path only if it's different
+        let stored_version = fs::read_to_string(&sync_version_file_path).await?;
+        if stored_version != version.tag_name {
+            fs::write(&sync_version_file_path, &version.tag_name).await?;
+            info!(
+                "Written version to {}",
+                sync_version_file_path
+                    .into_os_string()
+                    .into_string()
+                    .unwrap()
+            );
+        }
     }
 
     info!("You can now use {}!", version.tag_name);

--- a/src/modules/use_handler.rs
+++ b/src/modules/use_handler.rs
@@ -34,6 +34,17 @@ pub async fn start(version: InputVersion, client: &Client, config: Config) -> Re
 
     link_version(version_link, &config, is_version_used).await?;
     fs::write("used", &version.tag_name).await?;
+    if let Some(sync_version_file_path) = utils::get_sync_version_file_path(&config).await? {
+        fs::write(&sync_version_file_path, &version.tag_name).await?;
+        info!(
+            "Written version to {}",
+            sync_version_file_path
+                .into_os_string()
+                .into_string()
+                .unwrap()
+        );
+    }
+
     info!("You can now use {}!", version.tag_name);
 
     Ok(())

--- a/src/modules/utils.rs
+++ b/src/modules/utils.rs
@@ -92,6 +92,22 @@ pub async fn get_downloads_folder(config: &Config) -> Result<PathBuf> {
     Ok(path)
 }
 
+pub async fn get_sync_version_file_path(config: &Config) -> Result<Option<PathBuf>> {
+    let path = match &config.sync_version_file_path {
+        Some(path) => {
+            if let Err(e) = tokio::fs::metadata(path).await {
+                return Err(anyhow!(
+                    "Error when trying to retrieve sync_version_file_path {path}: {e}"
+                ));
+            }
+            Some(PathBuf::from(path))
+        }
+        None => return Ok(None),
+    };
+
+    Ok(path)
+}
+
 pub async fn remove_dir(directory: &str) -> Result<()> {
     let path = Path::new(directory);
     let size = path.read_dir()?.count();


### PR DESCRIPTION
#80 

Using `bob sync` will try to read a version stored at the configured `sync_version_file_path`. This is useful when using version control to track local configurations, where one might want to document when the version of neovim was changed (and to what version).

Note that this **does not** replace the `used` file in the downloads directory, `used` is regarded as the truth on the current installed neovim version, whereas `sync_version_file_path` can have any content, regardless of the current installed version.