### PR TITLE
Build with `--locked` flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --profile optimized
+          args: --locked --profile optimized
       - name: Check lints
         uses: actions-rs/cargo@v1
         with:
@@ -47,7 +47,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --profile optimized
+          args: --locked --profile optimized
       - name: Check lints
         uses: actions-rs/cargo@v1
         with:
@@ -77,7 +77,7 @@ jobs:
           uses: actions-rs/cargo@v1
           with:
             command: build
-            args: --profile optimized --target aarch64-apple-darwin
+            args: --locked --profile optimized --target aarch64-apple-darwin
         - name: Check lints
           uses: actions-rs/cargo@v1
           with:
@@ -107,7 +107,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --profile optimized
+          args: --locked --profile optimized
       - name: Check lints
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This PR updates the continuous integration workflow to always build with `--locked` flag for making sure that `Cargo.lock` is up-to-date.

It will help spotting issues like #89 early in the development phase.
