### PR TITLE
Fix: couldn't create downloads directory

### DIFF
--- a/src/helpers/directories.rs
+++ b/src/helpers/directories.rs
@@ -10,8 +10,7 @@ pub fn get_home_dir() -> Result<PathBuf> {
     }
 
     let mut home_str = if cfg!(target_os = "macos") {
-        let path = format!("{}{}/", "/Users/", std::env::var("USER")?);
-        return Ok(PathBuf::from(path.to_string()));
+        "/Users/".to_string()
     } else {
         "/home/".to_string()
     };

--- a/src/helpers/directories.rs
+++ b/src/helpers/directories.rs
@@ -10,7 +10,8 @@ pub fn get_home_dir() -> Result<PathBuf> {
     }
 
     let mut home_str = if cfg!(target_os = "macos") {
-        "/Users/".to_string()
+        let path = format!("{}{}/", "/Users/", std::env::var("USER")?);
+        return Ok(PathBuf::from(path.to_string()));
     } else {
         "/home/".to_string()
     };
@@ -67,8 +68,9 @@ pub async fn get_downloads_directory(config: &Config) -> Result<PathBuf> {
 
             data_dir.push("bob");
             let does_folder_exist = tokio::fs::metadata(&data_dir).await.is_ok();
+            let is_folder_created = tokio::fs::create_dir_all(&data_dir).await.is_ok();
 
-            if !does_folder_exist && tokio::fs::create_dir(&data_dir).await.is_err() {
+            if !does_folder_exist && !is_folder_created {
                 return Err(anyhow!("Couldn't create downloads directory"));
             }
             data_dir


### PR DESCRIPTION
- this resolves #112
- this uses `create_dir_all` to create even parent directories if it doesnt exist
  ```rust
  let is_folder_created = tokio::fs::create_dir_all(&data_dir).await.is_ok();
  ```

<img width="670" alt="image" src="https://user-images.githubusercontent.com/47204120/226151609-319942c1-9f77-4659-be10-77cee3d1a5f7.png">
