### PR TITLE
use HOME env as home dir if it is set

### DIFF
--- a/src/helpers/directories.rs
+++ b/src/helpers/directories.rs
@@ -11,6 +11,11 @@ pub fn get_home_dir() -> Result<PathBuf> {
         return Ok(home_str);
     }
 
+    if let Ok(value) = std::env::var("HOME") {
+        home_str = PathBuf::from(value);
+        return Ok(home_str)
+    }
+    
     if cfg!(target_os = "macos") {
         home_str.push("/Users/");
     } else {

--- a/src/helpers/directories.rs
+++ b/src/helpers/directories.rs
@@ -10,11 +10,6 @@ pub fn get_home_dir() -> Result<PathBuf> {
         home_str.push(std::env::var("USERPROFILE")?);
         return Ok(home_str);
     }
-
-    if let Ok(value) = std::env::var("HOME") {
-        home_str = PathBuf::from(value);
-        return Ok(home_str)
-    }
     
     if cfg!(target_os = "macos") {
         home_str.push("/Users/");
@@ -25,6 +20,11 @@ pub fn get_home_dir() -> Result<PathBuf> {
     if let Ok(value) = std::env::var("SUDO_USER") {
         home_str.push(&value);
         return Ok(home_str);
+    }
+
+    if let Ok(value) = std::env::var("HOME") {
+        home_str = PathBuf::from(value);
+        return Ok(home_str)
     }
 
     let env_value = std::env::var("USER")?;


### PR DESCRIPTION
In most cases on POSIX Systems (Linux/macOS) a HOME environment variable is set and contains the path to the home directory.

Before this fix, if running bob for example as root bob used `/home/root/` as the home directory, but the correct home directory is `/root/`.