### PR TITLE
Windows: Don't create a cmd window for nvim-qt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,23 +58,13 @@ async fn run() -> Result<()> {
             if #[cfg(windows)] {
                 use std::os::windows::process::CommandExt;
                 child.creation_flags(0x00000008);
-                println!("Spawned homie with creation flags fr");
             }
         }
 
+        child.spawn().expect("Failed to spawn child process");
+        return Ok(())
 
-        let mut child = child.spawn().expect("Failed to spawn child process");
 
-        let exit_status = child
-            .wait()
-            .expect("Failed to wait on child process")
-            .code();
-
-        match exit_status {
-            Some(0) => return Ok(()),
-            Some(code) => return Err(anyhow!("Process exited with error code {}", code)),
-            None => return Err(anyhow!("Process terminated by signal")),
-        }
     } else if exe_name.contains("nvim") {
         let rest_args = &args[1..];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![windows_subsystem = "windows"]
-
 mod cli;
 mod config;
 mod handlers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 mod cli;
 mod config;
 mod handlers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ async fn run() -> Result<()> {
             if #[cfg(windows)] {
                 use std::os::windows::process::CommandExt;
                 child.creation_flags(0x08000000);
+                println!("Spawned homie with creation flags fr");
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ async fn run() -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(windows)] {
                 use std::os::windows::process::CommandExt;
-                child.creation_flags(0x08000000);
+                child.creation_flags(0x00000008);
                 println!("Spawned homie with creation flags fr");
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,11 @@ async fn run() -> Result<()> {
     let exe_name = exe_name_path.file_name().unwrap().to_str().unwrap();
 
     if exe_name.contains("nvim-qt") {
+
+        if cfg!(unix) {
+            return Err(anyhow!("This is only usable on windows"));
+        }
+
         let rest_args = &args[1..];
 
         let downloads_dir = directories::get_downloads_directory(&config).await?;
@@ -62,9 +67,7 @@ async fn run() -> Result<()> {
         }
 
         child.spawn().expect("Failed to spawn child process");
-        return Ok(())
-
-
+        return Ok(());
     } else if exe_name.contains("nvim") {
         let rest_args = &args[1..];
 


### PR DESCRIPTION
fix #118 