### PR TITLE
feat(cli): add `complete [shell]` subcommand for tab-completion gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap",
+ "clap_complete",
  "dialoguer",
  "flate2",
  "futures-util",
@@ -183,6 +184,15 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c22dcfb410883764b29953103d9ef7bb8fe21b3fa1158bc99986c2067294bd"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rand = "0.8.5"
 serde_json = "1.0"
 yansi = "0.5.1"
 async-recursion = "1.0.2"
+clap_complete = "4.1"
 
 [dependencies.chrono]
 version = "0.4.23"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ List all installed and used versions.
 
 ---
 
+- `bob complete bash|elvish|fish|powershell|zsh`
+
+Generate shell completion.
+
+---
+
 ## ⚙ Configuration
 
 This section is a bit more advanced and thus the user will have to do the work himself since bob doesn't do that.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,93 @@ Bob's configuration file will have to be in `config_dir/bob/config.json`, to be 
 }
 ```
 
+## 💻 Shell Completion
+
+- Bash
+
+Completion files are commonly stored in `/etc/bash_completion.d/` for system-wide commands, but can be stored in `~/.local/share/bash-completion/completions` for user-specific commands. Run the command:
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+bob complete bash >> ~/.local/share/bash-completion/completions/bob
+```
+
+This installs the completion script. You may have to log out and log back in to your shell session for the changes to take effect.
+
+- Bash (macOS/Homebrew)
+
+Homebrew stores bash completion files within the Homebrew directory. With the `bash-completion` brew formula installed, run the command:
+
+```bash
+mkdir -p $(brew --prefix)/etc/bash_completion.d
+bob complete bash > $(brew --prefix)/etc/bash_completion.d/bob.bash-completion
+```
+
+- Fish
+
+Fish completion files are commonly stored in `$HOME/.config/fish/completions`. Run the command:
+
+```fish
+mkdir -p ~/.config/fish/completions
+bob complete fish > ~/.config/fish/completions/bob.fish
+```
+
+This installs the completion script. You may have to log out and log back in to your shell session for the changes to take effect.
+
+- Zsh
+
+Zsh completions are commonly stored in any directory listed in your `$fpath` variable. To use these completions, you must either add the generated script to one of those directories, or add your own to this list.
+
+Adding a custom directory is often the safest bet if you are unsure of which directory to use. First create the directory; for this example we'll create a hidden directory inside our `$HOME` directory:
+
+```zsh
+mkdir ~/.zfunc
+```
+
+Then add the following lines to your `.zshrc` just before `compinit`:
+
+```zsh
+fpath+=~/.zfunc
+```
+
+Now you can install the completions script using the following command:
+
+```zsh
+bob complete zsh > ~/.zfunc/_bob
+```
+
+You must then either log out and log back in, or simply run
+
+```zsh
+exec zsh
+```
+
+for the new completions to take effect.
+
+- PowerShell
+
+The PowerShell completion scripts require PowerShell v5.0+ (which comes with Windows 10, but can be downloaded separately for windows 7 or 8.1).
+
+First, check if a profile has already been set
+
+```powershell
+Test-Path $profile
+```
+
+If the above command returns `False` run the following
+
+```powershell
+New-Item -path $profile -type file -force
+```
+
+Now open the file provided by `$profile` (if you used the `New-Item` command it will be `${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+
+Next, we either save the completions file into our profile, or into a separate file and source it inside our profile. To save the completions into our profile simply use
+
+```powershell
+bob complete powershell >> ${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+```
+
 ## 🛠️ Troubleshooting
 
 `sudo: nvim: command not found`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,13 @@
-use crate::{config::Config, handlers::{self, sync_handler, uninstall_handler, rollback_handler, erase_handler, list_handler, InstallResult}};
+use crate::{
+    config::Config,
+    handlers::{
+        self, erase_handler, list_handler, rollback_handler, sync_handler, uninstall_handler,
+        InstallResult,
+    },
+};
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::Shell;
 use reqwest::Client;
 use tracing::info;
 
@@ -46,6 +53,12 @@ enum Cli {
     /// List all installed and used versions
     #[clap(visible_alias = "ls")]
     List,
+
+    /// Generate shell completion
+    Complete {
+        /// Shell to generate completion for
+        shell: Shell,
+    },
 }
 
 pub async fn start(config: Config) -> Result<()> {
@@ -89,6 +102,9 @@ pub async fn start(config: Config) -> Result<()> {
         Cli::Rollback => rollback_handler::start(config).await?,
         Cli::Erase => erase_handler::start(config).await?,
         Cli::List => list_handler::start(config).await?,
+        Cli::Complete { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "bob", &mut std::io::stdout())
+        }
     }
 
     Ok(())


### PR DESCRIPTION
At first I wanted to generate the completion files at compile time and then `include_str!` them in the binary (so that I could avoid adding yet another dependency), but that brought a lot of complexity into the code base which was completely unnecessary plus it made it impossible to access the `clap_complete::Shell` enum directly in the `Cli` enum.

Anyhow, I can do that if that seems to be a better option.