### PR TITLE
More reliable way to find stable release tag name

### DIFF
--- a/src/helpers/version/types.rs
+++ b/src/helpers/version/types.rs
@@ -20,6 +20,7 @@ pub enum VersionType {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UpstreamVersion {
     pub tag_name: String,
+    pub target_commitish: String,
     pub published_at: DateTime<Utc>,
 }
 


### PR DESCRIPTION
When I run `bob install stable` using bob-nvim 2.3.0, the nightly version is installed instead of the current stable v0.9.0
Seems related to changes in https://github.com/MordechaiHadad/bob/pull/124 which attempt to address the ordering change in [neovim release page](https://github.com/neovim/neovim/releases). But the ordering seems change again in my case.

So I am making this PR to suggest using the commit hash of stable release to search for the tag name, instead of relying on the ordering. Hope you agree and accept this change. Please let me know if you have any concern / code change you want me to adjust.

Thanks for making bob!

**A rough test of my change**
```
❯ ./target/debug/bob ls
┌───────────┬─────────────┐
│  Version  │  Status     │
├───────────┼─────────────┤
│  v0.8.0   │  Used       │
└───────────┴─────────────┘

❯ ./target/debug/bob install stable
Apr 11 13:27:45.606  INFO Fetching latest version
Downloaded version v0.9.0 to ...
  [00:00:00] [████████████████████████████] 11.78MiB/11.78MiB (26.49MiB/s, 0s)
Finished expanding to ...
  [00:00:01] [█████████████████████████████████████████████████████] 1692/1692
Apr 11 13:27:49.258  INFO v0.9.0 has been successfully installed in ...

❯ ./target/debug/bob ls
┌───────────┬─────────────┐
│  Version  │  Status     │
├───────────┼─────────────┤
│  v0.9.0   │  Installed  │
│  v0.8.0   │  Used       │
└───────────┴─────────────┘
```
