### PR TITLE
Config: Update all leftover references to sync_version_file_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Install the specified version, can also be used to update out-of-date nightly ve
 
 - `bob sync`
 
-If Config::sync_version_file_path is set, the version in that file will be parsed and installed.
+If Config::version_sync_file_location is set, the version in that file will be parsed and installed.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ enum Cli {
         version: String,
     },
 
-    /// If Config::sync_version_file_path is set, the version in that file
+    /// If Config::version_sync_file_location is set, the version in that file
     /// will be parsed and installed
     Sync,
 

--- a/src/handlers/sync_handler.rs
+++ b/src/handlers/sync_handler.rs
@@ -8,11 +8,11 @@ use crate::{config::Config, helpers::version};
 use super::use_handler;
 
 pub async fn start(client: &Client, config: Config) -> Result<()> {
-    let sync_version_file_path = version::get_sync_version_file_path(&config)
+    let version_sync_file_location = version::get_version_sync_file_location(&config)
         .await?
-        .ok_or_else(|| anyhow!("sync_version_file_path needs to be set to use bob sync"))?;
+        .ok_or_else(|| anyhow!("version_sync_file_location needs to be set to use bob sync"))?;
 
-    let version = fs::read_to_string(&sync_version_file_path).await?;
+    let version = fs::read_to_string(&version_sync_file_location).await?;
     if version.is_empty() {
         return Err(anyhow!("Sync file is empty"));
     }
@@ -24,7 +24,7 @@ pub async fn start(client: &Client, config: Config) -> Result<()> {
 
     info!(
         "Using version {version} set in {}",
-        sync_version_file_path
+        version_sync_file_location
             .into_os_string()
             .into_string()
             .unwrap()

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -56,16 +56,16 @@ pub async fn switch(config: &Config, version: &ParsedVersion) -> Result<()> {
 
     copy_nvim_bob(config).await?;
     fs::write("used", &version.tag_name).await?;
-    if let Some(sync_version_file_path) =
-        helpers::version::get_sync_version_file_path(config).await?
+    if let Some(version_sync_file_location) =
+        helpers::version::get_version_sync_file_location(config).await?
     {
-        // Write the used version to sync_version_file_path only if it's different
-        let stored_version = fs::read_to_string(&sync_version_file_path).await?;
+        // Write the used version to version_sync_file_location only if it's different
+        let stored_version = fs::read_to_string(&version_sync_file_location).await?;
         if stored_version != version.tag_name {
-            fs::write(&sync_version_file_path, &version.tag_name).await?;
+            fs::write(&version_sync_file_location, &version.tag_name).await?;
             info!(
                 "Written version to {}",
-                sync_version_file_path
+                version_sync_file_location
                     .into_os_string()
                     .into_string()
                     .unwrap()

--- a/src/helpers/version/mod.rs
+++ b/src/helpers/version/mod.rs
@@ -52,7 +52,7 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
     }
 }
 
-pub async fn get_sync_version_file_path(config: &Config) -> Result<Option<PathBuf>> {
+pub async fn get_version_sync_file_location(config: &Config) -> Result<Option<PathBuf>> {
     let path = match &config.version_sync_file_location {
         Some(path) => {
             if tokio::fs::metadata(path).await.is_err() {


### PR DESCRIPTION
Commit 8e56ea8 renamed `sync_version_file_path` to
`version_sync_file_location`, however some places still refer to the old name.

This is mostly relevant in the README and in the error messages (as `sync_version_file_path needs to be set to use bob sync` is still printed, which uses the wrong name and is quite confusing)

The commit was generated from this command running on MacOS
```bash
find src/**/* -type f | xargs sed -i '' -e 's/sync_version_file_path/version_sync_file_location/g'
```
(and then I also edited the README manually)