### PR TITLE
feat: add release build compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Example: `export BOB_CONFIG=/path/to/config/config.json`
 | Property                       | Description                                                                                                                                                    | Default Value                                                                                                 |
 | -------------------------------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------------------------------------|
 | **enable_nightly_info**        | Will show new commits associated with new nightly release if enabled                                                                                           | `true`                                                                                                        |
+| **enable_release_build**       | Compile neovim nightly or a certain hash version as a release build (slightly improved performance, no debug info)                                        | `false`                                                                                                       |
 | **downloads_location**         | The folder in which neovim versions will be downloaded to, bob will error if this option is specified but the folder doesn't exist                             | unix: `/home/<username>/.local/share/bob`, windows: `C:\Users\<username>\AppData\Local\bob`                   |
 | **installation_location**      | The path in which the proxied neovim installation will be located in                                                                                           | unix: `/home/<username>/.local/share/bob/nvim-bin`, windows: `C:\Users\<username>\AppData\Local\bob\nvim-bin` |
 | **version_sync_file_location** | The path to a file that will hold the neovim version string, useful for config version tracking, bob will error if the specified file is not a valid file path | `Disabled by default`                                                                                         |
@@ -203,6 +204,7 @@ Example: `export BOB_CONFIG=/path/to/config/config.json`
 // /home/user/.config/bob/config.json
 {
   "enable_nightly_info": true, // Will show new commits associated with new nightly release if enabled
+  "enable_release_build": false, // Compile neovim nightly or a certain hash version as a release build (slightly improved performance, no debug info)
   "downloads_location": "$HOME/.local/share/bob", // The folder in which neovim versions will be installed too, bob will error if this option is specified but the folder doesn't exist
   "installation_location": "/home/user/.local/share/bob/nvim-bin", // The path in which the used neovim version will be located in
   "version_sync_file_location": "/home/user/.config/nvim/nvim.version", // The path to a file that will hold the neovim version string, useful for config version tracking, bob will error if the specified file is not a valid file path

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use tokio::fs;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub enable_nightly_info: Option<bool>,
+    pub enable_release_build: Option<bool>,
     pub downloads_location: Option<String>,
     pub installation_location: Option<String>,
     pub version_sync_file_location: Option<String>,
@@ -24,6 +25,7 @@ pub async fn handle_config() -> Result<Config> {
         }
         Err(_) => Config {
             enable_nightly_info: None,
+            enable_release_build: None,
             downloads_location: None,
             installation_location: None,
             version_sync_file_location: None,


### PR DESCRIPTION
Hey!

Personally I like to compile my nightly builds as a release for performance improvements. For that I have slightly refactored the code to check for this config option and to compile neovim nightly instead of downloading the pre-built binary in case this setting is enabled. It should also work for specific hash installations.

Currently `Make` has issues with those changes and returns the following:
```sh
/Library/Developer/CommandLineTools/usr/bin/make -C build install
[  0%] Built target update_version_stamp
[  4%] Built target nlua0
[ 91%] Built target nvim
[ 91%] Built target nvim_runtime_deps
[100%] Built target translations
[100%] Built target runtime
Install the project...
-- Install configuration: "Release"
Jul 16 22:54:15.055 ERROR Error: No such file or directory (os error 2)
```

I'll be investigating the cause later today in case this addition is even desired.

EDIT: My current suspicions are:

- [Line 274](https://github.com/owittek/bob/blob/4b122c7aa5d0da6cbb4d0f904d16843849407c91/src/handlers/install_handler.rs#L274) as it's not cloning with `--branch nightly` (--branch actually matches tags too)
- [Cache issues](https://github.com/neovim/neovim/wiki/Building-Neovim#building) (see bottom of this section)