### PR TITLE
fix: fix Windows paths

### DIFF
--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -302,7 +302,7 @@ async fn copy_file_with_error_handling(old_path: &Path, new_path: &Path) -> Resu
 /// add_to_path(&installation_dir).unwrap();
 /// ```
 fn add_to_path(installation_dir: &Path) -> Result<()> {
-    let installation_dir = installation_dir.to_str().unwrap();
+    let installation_dir = installation_dir.to_str().unwrap().replace('/', "\\");
 
     cfg_if::cfg_if! {
         if #[cfg(windows)] {
@@ -313,7 +313,7 @@ fn add_to_path(installation_dir: &Path) -> Result<()> {
             let env = current_usr.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)?;
             let usr_path: String = env.get_value("Path")?;
 
-            if usr_path.contains(installation_dir) {
+            if usr_path.to_lowercase().replace('/', "\\").contains(&installation_dir.to_lowercase()) {
                 return Ok(());
             }
 

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -302,7 +302,7 @@ async fn copy_file_with_error_handling(old_path: &Path, new_path: &Path) -> Resu
 /// add_to_path(&installation_dir).unwrap();
 /// ```
 fn add_to_path(installation_dir: &Path) -> Result<()> {
-    let installation_dir = installation_dir.to_str().unwrap().replace('/', "\\");
+    let installation_dir = installation_dir.to_str().unwrap();
 
     cfg_if::cfg_if! {
         if #[cfg(windows)] {
@@ -312,8 +312,11 @@ fn add_to_path(installation_dir: &Path) -> Result<()> {
             let current_usr = RegKey::predef(HKEY_CURRENT_USER);
             let env = current_usr.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)?;
             let usr_path: String = env.get_value("Path")?;
+            let usr_path_lower = usr_path.replace('/', "\\").to_lowercase();
+            let installation_dir = installation_dir.replace('/', "\\");
+            let installation_dir_lower = installation_dir.to_lowercase();
 
-            if usr_path.to_lowercase().replace('/', "\\").contains(&installation_dir.to_lowercase()) {
+            if usr_path_lower.contains(&installation_dir_lower) {
                 return Ok(());
             }
 

--- a/src/helpers/directories.rs
+++ b/src/helpers/directories.rs
@@ -76,7 +76,7 @@ pub fn get_home_dir() -> Result<PathBuf> {
 pub fn get_local_data_dir() -> Result<PathBuf> {
     let mut home_dir = get_home_dir()?;
     if cfg!(windows) {
-        home_dir.push("AppData/Local");
+        home_dir.push("AppData\\Local");
         return Ok(home_dir);
     }
 
@@ -109,7 +109,7 @@ pub fn get_config_file() -> Result<PathBuf> {
     let mut home_dir = get_home_dir()?;
 
     if cfg!(windows) {
-        home_dir.push("AppData/Roaming");
+        home_dir.push("AppData\\Roaming");
     } else if cfg!(target_os = "macos") {
         home_dir.push("Library/Application Support");
     } else {


### PR DESCRIPTION
This PR addresses two issues with Windows paths:

1. `AppData/Local` and `AppData/Roaming` were changed to use backslashes instead of forward slashes.
2. When checking if the installation directory has already been added to the path, the paths are normalized by changing forward slashes to backslashes as well as doing a case-insensitive comparison to avoid duplicate paths being added with different casing or slashes.