### PR TITLE
doc(cli): avoid including code comment in help output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ fn create_reqwest_client() -> Result<Client, Error> {
     Ok(client)
 }
 
-/// The `Cli` enum represents the different commands that can be used in the command-line interface.
+// The `Cli` enum represents the different commands that can be used in the command-line interface.
 #[derive(Debug, Parser)]
 #[command(version)]
 enum Cli {


### PR DESCRIPTION
In the 4.0.3 release, the root `bob` help output currently looks like this:

```
The `Cli` enum represents the different commands that can be used in the command-line interface

Usage: bob <COMMAND>

Commands:
  use          Switch to the specified version, by default will auto-invoke install command if the version is not installed already
  install      Install the specified version, can also be used to update out-of-date nightly version
  sync         If Config::version_sync_file_location is set, the version in that file will be parsed and installed
  uninstall    Uninstall the specified version [aliases: rm]
  rollback     Rollback to an existing nightly rollback
  erase        Erase any change bob ever made, including neovim installation, neovim version downloads and registry changes
  list         List all installed and used versions [aliases: ls]
  list-remote  [aliases: ls-remote]
  complete     Generate shell completion
  update       Update existing version |nightly|stable|--all|
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

The top text is taken from a code comment, and looks a bit out of place, this PR makes it an internal comment so that clap doesn't mistake it for app description. 