### PR TITLE
build: add cargo-binstall support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap_complete = "4.1"
 toml = "0.8.8"
 semver = "1.0.22"
 sha2 = "0.10.8"
-what-the-path = "^0.1.3" 
+what-the-path = "^0.1.3"
 sysinfo = "0.35.2"
 
 [dependencies.chrono]
@@ -106,3 +106,18 @@ opt-level = "z"
 strip = true
 lto = true
 codegen-units = 1
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/bob-{ target-family }-{ target-arch }{ archive-suffix }"
+bin-dir = "bob-{ target-family }-{ target-arch }/{ bin }{ binary-ext }"
+pkg-fmt = "zip"
+disabled-strategies = ["quick-install"]
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/bob-macos-arm.{ archive-format }"
+bin-dir = "bob-macos-arm/{ bin }"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/bob-macos-x86_64.{ archive-format }"
+bin-dir = "bob-macos-x86_64/{ bin }"
+


### PR DESCRIPTION
Support [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) by adding the manifest fields to the `Cargo.toml` according to [this documentation](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md). `cargo binstall` reads the manifest to automatically install binaries instead of building. Currently cargo-binstall will install from [quick install](https://github.com/cargo-bins/cargo-quickinstall) which installs incorrect binaries on macos (x86_64 instead of arm).

An alternative to changing the manifest is to change the names of the release artifacts so that it can be automatically detected by `cargo binstall`. Let me know if this is preferred.

Tested by running and verifying architecture with `file`:
- `cargo binstall --force --manifest-path . --root . bob-nvim`, installed the arm version on my mac correctly
- `cargo binstall --force --targets <target> --manifest-path . --root . bob-nvim`
  - Following values for `<target>` were tested:
    - `aarch64-apple-darwin`
    - `x86_64-apple-darwin`
    - `x86_64-pc-windows-msvc`
    - `x86_64-unknown-linux-gnu`
