### PR TITLE
Bugfix/upgrade deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustls-tls = ["reqwest/rustls-tls-native-roots"]
 [dependencies]
 anyhow = "1.0.52"
 cfg-if = "1.0"
-indicatif = "0.16.2"
+indicatif = "0.17.8"
 rand = "0.8.5"
 serde_json = "1.0"
 yansi = "0.5.1"

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -362,7 +362,7 @@ async fn download_version(
                         // Progress Bar Setup
                         let pb = ProgressBar::new(total_size);
                         pb.set_style(ProgressStyle::default_bar()
-                    .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
+                    .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")?
                     .progress_chars("█  "));
                         let dl = if get_sha256sum { "checksum" } else { "version" };
                         pb.set_message(format!("Downloading {dl}: {}", version.tag_name));

--- a/src/helpers/filesystem.rs
+++ b/src/helpers/filesystem.rs
@@ -35,7 +35,7 @@ pub async fn remove_dir(directory: &str) -> Result<()> {
 
     let pb = ProgressBar::new(size.try_into()?);
     pb.set_style(ProgressStyle::default_bar()
-                    .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({per_sec}, {eta})")
+                    .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({per_sec}, {eta})")?
                     .progress_chars("█  "));
     pb.set_message(format!("Deleting {}", path.display()));
 

--- a/src/helpers/unarchive.rs
+++ b/src/helpers/unarchive.rs
@@ -123,7 +123,7 @@ fn expand(downloaded_file: LocalVersion) -> Result<()> {
         ProgressStyle::default_bar()
             .template(
                 "{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len}",
-            )
+            )?
             .progress_chars("█  "),
     );
     pb.set_message("Expanding archive");
@@ -235,7 +235,7 @@ fn expand(downloaded_file: LocalVersion) -> Result<()> {
         ProgressStyle::default_bar()
             .template(
                 "{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len}",
-            )
+            )?
             .progress_chars("█  "),
     );
     pb.set_message("Expanding archive");


### PR DESCRIPTION
Installation via `cargo install --git https://github.com/MordechaiHadad/bob.git` failed due to issues with the `indicatif` library:

```
error[E0432]: unresolved imports `console::measure_text_width`, `console::Style`
  --> /home/joseph/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indicatif-0.16.2/src/utils.rs:7:15
   |
7  | use console::{measure_text_width, Style};
   |               ^^^^^^^^^^^^^^^^^^  ^^^^^ no `Style` in the root
   |               |
   |               no `measure_text_width` in the root
```

Quick fix authored via Aider. Upgraded dependency and fixed resulting issues. 