### PR TITLE
pin console explicitly to v0.15.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "console",
  "dialoguer",
  "flate2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ native-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls-native-roots"]
 
 [dependencies]
+console = "0.15.11"
 anyhow = "1.0.52"
 cfg-if = "1.0"
 indicatif = "0.16.2"


### PR DESCRIPTION
The Console crate has pushed a breaking API change in 0.16.0 which hides the
necessary APIs behind a feature flag that isn't supplied by default. As a
result, indicatif fails to compile when running `cargo install bob-nvim`. This
patch fixes this issue by pinning the console crate to v0.15.11. Which is the
version referenced in our lock file. 

Fixes #298
