### PR TITLE
fix (309): check that used starts with listed version

### DIFF
--- a/src/helpers/version/mod.rs
+++ b/src/helpers/version/mod.rs
@@ -284,7 +284,7 @@ pub async fn get_current_version(config: &Config) -> Result<String> {
 /// ```
 pub async fn is_version_used(version: &str, config: &Config) -> bool {
     match get_current_version(config).await {
-        Ok(value) => value.eq(version),
+        Ok(value) => value.starts_with(version),
         Err(_) => false,
     }
 }


### PR DESCRIPTION
with this PR, when listing currently installed versions, let's call one of them _v_,
`bob list` will check whether or not the currently "_used_" version _starts with_ _v_
instead of _is strictly equal to_ _v_.

> [!NOTE]
> this is the new version of the PR, after review from @MordechaiHadad

#### Pros:
- issue #309 is fixed because the rendering of "used" works

#### Cons:
- i do not think there really are downsides to this new version !

#### Comparison
- before
```
┌───────────┬─────────────┐
│  Version  │  Status     │
├───────────┼─────────────┤
│  v0.11.3  │  Installed  │
│  68eece8  │  Installed  │
└───────────┴─────────────┘
```
- after
```
┌───────────┬─────────────┐
│  Version  │  Status     │
├───────────┼─────────────┤
│  v0.11.3  │  Installed  │
│  68eece8  │  Used       │
└───────────┴─────────────┘
```

## Changelog
- **check that value (used) starts with version**
