### PR TITLE
add a Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 profile = "default"
 channel = "1.86.0"
+components = [ "rust-analyzer" ]


### PR DESCRIPTION
i was in the middle of writing #315 when i thought having a Rust toolchain could be useful to
- pin the version of Rust (i used 1.86)
- install Rust components (i wanted `rust-analyzer` for some LSP support)

## changelog
- **add a Rust toolchain**
- **toolchain: add rust-analyzer**
