### PR TITLE
fix(#321): refactor add_to_path + sep. OS logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,15 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1478,17 +1469,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1499,14 +1481,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2166,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -2176,35 +2152,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
- "serde",
- "serde_json",
+ "nu-ansi-term",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,12 @@ features = ["full"]
 optional = false
 
 [dependencies.tracing]
-version = "0.1"
+version = "0.1.41"
 features = []
 optional = false
 
 [dependencies.tracing-subscriber]
-version = "0.2"
+version = "0.3.20"
 optional = false
 
 [target.'cfg(unix)'.dependencies.nix]

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -480,6 +480,7 @@ async fn modify_path(config: &ConfigFile, installation_dir: &str) -> Result<()> 
 // This is a change in the 2024 edition and up-
 // Read more in the `use` docs under `precise capturing`.
 //
+#[cfg(not(target_family = "windows"))]
 fn get_rc_files_from_shell(
     shell: &what_the_path::shell::Shell,
 ) -> Result<Vec<impl AsRef<Path> + use<>>> {
@@ -491,6 +492,7 @@ fn get_rc_files_from_shell(
     })
 }
 
+#[cfg(not(target_family = "windows"))]
 async fn create_if_not_exist<P>(file_path: P, env_path: &str) -> Result<()>
 where
     P: AsRef<Path>,
@@ -516,11 +518,15 @@ where
     Ok(())
 }
 
+#[cfg(not(target_family = "windows"))]
 #[derive(Debug)]
 struct FishScriptPath<F>(F);
+
+#[cfg(not(target_family = "windows"))]
 #[derive(Debug)]
 struct ShScriptPath<S>(S);
 
+#[cfg(not(target_family = "windows"))]
 impl<F> std::ops::Deref for FishScriptPath<F> {
     type Target = F;
 
@@ -529,6 +535,7 @@ impl<F> std::ops::Deref for FishScriptPath<F> {
     }
 }
 
+#[cfg(not(target_family = "windows"))]
 impl<S> std::ops::Deref for ShScriptPath<S> {
     type Target = S;
 
@@ -537,12 +544,14 @@ impl<S> std::ops::Deref for ShScriptPath<S> {
     }
 }
 
+#[cfg(not(target_family = "windows"))]
 #[derive(Debug)]
 struct EnvPaths<F, S> {
     fish_script: F,
     sh_script: S,
 }
 
+#[cfg(not(target_family = "windows"))]
 impl<F, S> From<(F, S)> for EnvPaths<F, S> {
     fn from(paths: (F, S)) -> Self {
         EnvPaths {
@@ -552,6 +561,7 @@ impl<F, S> From<(F, S)> for EnvPaths<F, S> {
     }
 }
 
+#[cfg(not(target_family = "windows"))]
 type EnvPathsBufs = EnvPaths<FishScriptPath<PathBuf>, ShScriptPath<PathBuf>>;
 
 #[cfg(not(target_family = "windows"))]
@@ -593,6 +603,7 @@ async fn copy_env_files_if_not_exist(
     )))
 }
 
+#[cfg(not(target_family = "windows"))]
 #[cfg(test)]
 mod use_handler_tests {
     use super::*;


### PR DESCRIPTION
## Summary 

Closes #321 

Refactor add_to_path for handling non-interactive shells and separate OS logic to compile time
guarded functions.


Changes are mostly the addition of a guard check if we're interactive on either stdout/stderr, wrapping prompt with tokio::time::timeout, and moving the temp config to use a RefCell over cloning.

## Testing

Currently requires end-user testing, will have to further refactor for mod_tests and proper testing between unix/windows OS's.