### PR TITLE
fix(#324): Handle Env. Var starting `$` sign

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -197,7 +197,11 @@ impl EnvVarProcessor for Option<String> {
     fn process(&mut self) -> Result<()> {
         if let Some(value) = self {
             if ENVIRONMENT_VAR_REGEX.is_match(value) {
-                let extract = ENVIRONMENT_VAR_REGEX.find(value).map_or("", |m| m.as_str());
+                let mut extract = ENVIRONMENT_VAR_REGEX.find(value).map_or("", |m| m.as_str());
+
+                if extract.chars().count() >= 2 && extract.starts_with('$') {
+                    extract = &extract[1..];
+                }
 
                 let var = env::var(extract).expect("Failed to get environment variable");
 


### PR DESCRIPTION
Fixes a regression introduced in #d6813be8 and highlighted as a critical issue in #324
Where the change from using `.capture().unwrap().get(1)` would already omit the `$` sign.
This resolves this  by doing an in-place truncation and dropping the `$` sign for matching purposes.