### PR TITLE
hotfix/perf(#331): removes padding on list-remote output

### DIFF
--- a/src/handlers/list_remote_handler.rs
+++ b/src/handlers/list_remote_handler.rs
@@ -124,20 +124,14 @@ pub async fn start(config: Config, client: Client) -> Result<()> {
     }
 
     let mut stdout = io::stdout().lock();
-    stdout.write_all(&buffer).unwrap_or_else(|e| {
+    stdout.write_all(&buffer).map_err(|e| {
         if e.kind() == io::ErrorKind::BrokenPipe {
-            eprintln!("Error writing to stdout (BrokenPipe): {}", e);
-            stdout.flush().unwrap_or(());
+            return anyhow::anyhow!("Failed to write to stdout: Broken pipe");
         }
-        eprintln!("Error writing to stdout (BrokenPipe): {}", e);
-        stdout.flush().unwrap_or(());
-    });
-    stdout.flush().unwrap_or_else(|e| {
-        if e.kind() != io::ErrorKind::BrokenPipe {
-            eprintln!("Error flushing stdout: {}", e);
-        }
-        stdout.flush().unwrap_or(());
-    });
+        e.into()
+    })?;
+
+    stdout.flush()?;
 
     Ok(())
 }


### PR DESCRIPTION
# Summary 

Removal of padding when calling `bob list-remote`


The padding variable and associated usage in the `list_remote_handler.rs` file have been removed.

## Performance change 

There's no need to request an `io::stdout` lock any early than the moment we require output.
To achieve this I've used a `Vec::with_capacity(1024)` via a buffer (basically a char buffer).
Outputting to this via ` writeln!(...)` and only calling the `io::stdout().lock()` after the `if-else` chain.

I've also implemented explicit error output handling for `io::ErrorKind::BrokenPipe` and added proper flushing for the stdout lock.