### PR TITLE
fix: cannot find stable release

### DIFF
--- a/src/helpers/version/mod.rs
+++ b/src/helpers/version/mod.rs
@@ -284,7 +284,7 @@ pub async fn is_version_used(version: &str, config: &Config) -> bool {
 /// ```
 pub async fn search_stable_version(client: &Client) -> Result<String> {
     let response = client
-        .get("https://api.github.com/repos/neovim/neovim/releases?per_page=10")
+        .get("https://api.github.com/repos/neovim/neovim/releases?per_page=15")
         .header("user-agent", "bob")
         .header("Accept", "application/vnd.github.v3+json")
         .send()


### PR DESCRIPTION
## Summary :

<img width="1083" height="540" alt="image" src="https://github.com/user-attachments/assets/dd31d2fe-f18d-4bc4-9d34-506c5e11c9da" />

refs: https://github.com/MordechaiHadad/bob/blob/master/src/helpers/version/mod.rs#L285

- this section of the code is responsible for find the `stable` tag name by making a GET request to the url `https://api.github.com/repos/neovim/neovim/releases?per_page=10`, but it couldn't find the `stable` tag name from the response contents. so it gives a error `Cannot find stable release`

<img width="987" height="301" alt="image" src="https://github.com/user-attachments/assets/990370d5-b960-4f5c-871e-b7c6bc0c2f2b" />

<img width="1006" height="146" alt="image" src="https://github.com/user-attachments/assets/52099312-2333-4620-8cc3-79b5337f1bf8" />

- by just increasing the `per_page` param from `10` to `15`, it is able to find the `stable` release.
here are some pics of making a GET request to the url `https://api.github.com/repos/neovim/neovim/releases?per_page=15` and greping the `stable` release in the response contents.

<img width="948" height="492" alt="image" src="https://github.com/user-attachments/assets/11c490e3-c2ce-404e-9965-b4805cb1b468" />

<img width="895" height="334" alt="image" src="https://github.com/user-attachments/assets/ca21612a-4123-49e8-96b7-33970d6967c2" />


### TL;DR

- increase the `per_page` count from `10` to `15`.