### PR TITLE
fix(#357): comp-time Win. ext. for run handler

### DIFF
--- a/src/handlers/run_handler.rs
+++ b/src/handlers/run_handler.rs
@@ -36,11 +36,11 @@ pub async fn start(version: &str, args: &[String], client: &Client, config: &Con
     }
 
     // Use the specific version's binary (With OS specific extension)
-    #[cfg(not(target_family = "windows"))]
-    let bin_path = version_path.join("bin").join("nvim");
-
-    #[cfg(target_family = "windows")]
-    let bin_path = version_path.join("bin").join("nvim").with_extension("exe");
+    let bin_path = if cfg!(target_family = "windows") {
+        version_path.join("bin").join("nvim").with_extension("exe")
+    } else {
+        version_path.join("bin").join("nvim")
+    };
 
     if !bin_path.exists() {
         anyhow::bail!(


### PR DESCRIPTION
This addresses issue #357  by adding comp-time handling for Windows systems.
Previously the `run_handler` fn was not not correctly appending the `.exe` extension to the Neovim binary path, this hot-fix addresses this.

Closes #357 