### PR TITLE
feat(#345): Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,104 @@
+name: "Bug Report"
+description: "File a bug report to help us improve"
+title: "[BUG]: "
+labels: ["bug"]
+# labels: ["bug", "triage"]
+assignees: []
+body:
+  - type: input
+    id: "bob_version"
+    attributes:
+      label: "Bob Version"
+      description: "Run `bob --version` and paste the output here."
+      placeholder: "ex: bob 1.0.0"
+    validations:
+      required: true
+  - type: "input"
+    id: "rust_version"
+    attributes:
+      label: "Rust Version"
+      description: "Run `rustc --version` and paste the output here. (Optional if you're not building `bob` from source.)"
+      placeholder: "ex: rustc 1.75.0 (82e1608df 2023-12-21)"
+    validations:
+      required: false
+  - type: input
+    id: "os_arch"
+    attributes:
+      label: "Operating System and Architecture"
+      description: "Please provide your OS and architecture. (You can find this by running `uname -a` on Linux/macOS or `systeminfo` on Windows.)"
+      placeholder: "ex: Ubuntu 22.04, x86_64"
+    validations:
+      required: true
+  # Alternative: use dropdowns for OS and architecture (uncomment and replace the input above if preferred)
+  #  - type: dropdown
+  #    id: os
+  #    attributes:
+  #      label: Operating System
+  #      options:
+  #        - Windows
+  #        - Linux
+  #        - macOS
+  #        - Other
+  #    validations:
+  #      required: true
+  #  - type: dropdown
+  #    id: arch
+  #    attributes:
+  #      label: Architecture
+  #      options:
+  #        - x86_64
+  #        - aarch64
+  #        - armv7
+  #        - Other
+  #    validations:
+  #      required: true
+  - type: textarea
+    id: "description"
+    attributes:
+      label: "Describe the Bug"
+      description: "A clear and concise description of what the bug is."
+      placeholder: "Tell us what happened."
+    validations:
+      required: true
+  - type: textarea
+    id: "steps"
+    attributes:
+      label: "Steps to Reproduce"
+      description: "Steps to reproduce the behavior."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: "behavior"
+    attributes:
+      label: "Expected vs Actual Behavior"
+      description: "A clear and concise description of what you expected to happen versus what actually happened."
+      placeholder: |
+        The expected behavior was...
+
+        The actual behavior was...
+
+    validations:
+      required: true
+  - type: textarea
+    id: "logs"
+    attributes:
+      label: "Logs/Errors"
+      description: |
+        Please provide any relevant logs or error messages.
+        For long logs, wrap them in a collapsible section using Markdown:
+        <details><summary>Click to expand logs</summary>
+        Paste your log here
+        </details>
+      placeholder: "Paste logs or errors here, using the collapsible format if lengthy."
+  - type: textarea
+    id: "config"
+    attributes:
+      label: "Config File (if relevant)"
+      description: "If relevant, please paste the contents of your config file. The default location is `~/.config/bob/config.json`. If not relevant or unchanged, you can enter 'No custom config'."
+      placeholder: 'Paste config here, or "No custom config"'
+      render: json

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,39 @@
+name: "Feature Request"
+description: "Suggest an idea for the project"
+title: "[FEAT]: "
+labels: ["feat"]
+# labels: ["feat", "enhancement"]
+assignees: []
+body:
+  - type: textarea
+    id: "problem"
+    attributes:
+      label: "Is your feature request related to a problem? Please describe. (Provide a link to the issue if there's already one open using `#<number>`)"
+      description: "A clear and concise description of what the problem is."
+      placeholder: "ex. I'm always frustrated when [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: "solution"
+    attributes:
+      label: "Describe the solution you'd like"
+      description: "A clear and concise description of what you want to happen."
+      placeholder: "ex. It would be great if [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: "alternatives"
+    attributes:
+      label: "Describe alternatives you've considered"
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+      placeholder: "ex. I thought about using [...] but [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: "context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context or screenshots about the feature request here."
+      placeholder: "ex. Links, images, or more details."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-docs-problem.yml
+++ b/.github/ISSUE_TEMPLATE/03-docs-problem.yml
@@ -1,0 +1,38 @@
+name: "Documentation Issue"
+description: "Report an issue or suggest improvements to the documentation"
+title: "[DOCS]: "
+labels: ["docs"]
+assignees: []
+body:
+  - type: textarea
+    id: "description"
+    attributes:
+      label: "Describe the Documentation Issue"
+      description: "A clear and concise description of the issue with the documentation."
+      placeholder: "ex. The section on installation is unclear because..."
+    validations:
+      required: false
+  - type: input
+    id: "location"
+    attributes:
+      label: "Location in Documentation"
+      description: "Provide the URL, file path, or section where the issue is found."
+      placeholder: "ex. https://example.com/docs/installation or README.md#installation"
+    validations:
+      required: false
+  - type: textarea
+    id: "proposed_changes"
+    attributes:
+      label: "Proposed Changes"
+      description: "Describe any suggested fixes or improvements."
+      placeholder: "ex. It would be better if we added an example like..."
+    validations:
+      required: false
+  - type: textarea
+    id: "context"
+    attributes:
+      label: "Additional Context"
+      description: "Add any other context, screenshots, or details about the documentation issue here."
+      placeholder: "ex. Links, images, or more details."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-build-problem.yml
+++ b/.github/ISSUE_TEMPLATE/04-build-problem.yml
@@ -1,0 +1,80 @@
+name: Build Problem
+description: Report a problem with building Bob or Neovim versions
+title: "[BUILD]: "
+labels: [build-problem]
+assignees: []
+body:
+  - type: textarea
+    id: "description"
+    attributes:
+      label: "Describe the Build Problem"
+      description: "A clear and concise description of the build issue you are encountering."
+      placeholder: "Tell us what happened during the build process."
+    validations:
+      required: true
+  - type: textarea
+    id: "os-arch-distro"
+    attributes:
+      label: "OS, Architecture, and Distro (if Linux)"
+      description: |
+        Please provide your operating system, architecture, and Linux distribution if applicable.
+        You can find this by running `uname -a` on Linux/macOS or `systeminfo` on Windows.
+      placeholder: "ex: Linux Ubuntu 22.04, x86_64"
+    validations:
+      required: true
+  - type: dropdown
+    id: "compiler"
+    attributes:
+      label: "Compiler"
+      description: "Which compiler are you using?"
+      options:
+        - "GCC"
+        - "Clang"
+        - "MSVC"
+        - "Other"
+    validations:
+      required: true
+  - type: input
+    id: "rust-version"
+    attributes:
+      label: "Rust Version"
+      description: "Run `rustc --version` and paste the output here."
+      placeholder: "ex: rustc 1.75.0 (82e1608df 2023-12-21)"
+    validations:
+      required: true
+  - type: textarea
+    id: "diagnosis"
+    attributes:
+      label: "Diagnosis Attempt"
+      description: |
+        Please attempt to diagnose whether the build failure is with Bob itself or with downloading/building a Neovim version.
+        Try using `bob use <version>` with a nightly version (which builds from the git repo) and a stable non-nightly version (e.g., 0.11.0).
+        Describe what happened in each case.
+      placeholder: |
+        ex: When using nightly: 
+        ... 
+
+        ex: When using stable 0.11.0: 
+        ...
+
+    validations:
+      required: true
+  - type: textarea
+    id: "logs"
+    attributes:
+      label: "Logs/Error Messages"
+      description: |
+        Please provide any relevant logs or error messages.
+        For long logs, wrap them in a collapsible section using Markdown:
+        <details><summary>Click to expand logs</summary>
+        Paste your log here
+        </details>
+      placeholder: "Paste logs or errors here, using the collapsible format if lengthy."
+  - type: textarea
+    id: "build_output"
+    attributes:
+      label: "Build Output (if applicable)"
+      description: |
+        If applicable, paste the build output here.
+        For long outputs, use a collapsible section as above.
+      placeholder: "Paste build output here."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/MordechaiHadad/bob/discussions
+    about: When you have questions or need help, please visit our GitHub Discussions page.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+---
+name: "Pull Request"
+title: "[fix/feat/docs/ci]:"
+
+---
+
+## Summary
+
+- Fixes #`<issue>`
+or 
+- Closes #`<issue>`
+
+Please include a summary of the change and which issue it fixes/closes.
+
+> Please also include relevant motivation and context.
+
+## Description
+
+Please provide a reasonable length description of what you did in the PR. 
+This helps reviewers get a clear understanding quickly of what's been done.
+
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+
+## Checklist:
+
+1. Conformity
+  - [ ] My code follows the style guidelines of this project
+  - [ ] Code is formatted with `cargo fmt`
+  - [ ] No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)
+
+2. Best-Effort
+
+  - [ ] My changes generate no new warnings
+  - [ ] I have performed a self-review of my own code
+  - [ ] I have commented my code, particularly in hard-to-understand areas
+
+3. Documentation
+
+  - [ ] Any documentation that relates to this PR has been updated, or will be updated in a PR (Link here: )(if applicable)
+
+4. Tests
+
+  - [ ] I have added tests that prove my fix is effective or that my feature works
+  - [ ] New and existing unit tests pass locally with my changes
+
+5. Dependencies
+
+  - [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
  # Summary
  
  Closes: #345 
  
## Details

This pull request provides `Issue` templates as outlined in the referenced `Issue` number 345. Adding template system to the repo to assist with formatting and allowing contributors and maintainers to easily scan through submitted reports.

Happy to make tweaks or changes as needed as I believe these will be quite helpful in ensuring conformity across submitted items plus with the requirement of `Issue` -> `Pull Request` this fits nicely.

### Testing

Regarding testing, I'll need to directly test these due to how GitHub forks <> Issues interact.
@MordechaiHadad - If you're able to pull this into it's own branch & allow for closing/tagging etc. on that branch this would be very helpful; otherwise will have to create a dummy repo. Comfortable with either approach.