### PR TITLE
Fix command for Nushell completions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Nushell completions are commonly stored in `($nu.data-dir)/completions`. Run:
 
 ```nu
 mkdir ($nu.data-dir | path join "completions")
-bob complete nu | save -f ($nu.data-dir | path join "completions/bob.nu")
+bob complete nushell | save -f ($nu.data-dir | path join "completions/bob.nu")
 ```
 
 To generate the completion file. Then, in order to automatically load the completions on startup, add:


### PR DESCRIPTION
# Summary

Simple README fix, typo in example completion command, `nu` -> `nushell`

## Type of change

> Please delete options that are not relevant.
- [ X ] - Documentation update


