### PR TITLE
System passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tar",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ optional = false
 version = "0.3.20"
 optional = false
 
+[dev-dependencies]
+tempfile = "3.8"
+
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.28.0"
 features = ["signal"]

--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ For the OpenSSL version:
 
 A version-string can either be `vx.x.x` or `x.x.x` examples: `v0.6.1` and `0.6.0`
 
+Bob also supports a special `system` version that allows you to use the Neovim binary installed on your system (via package managers like Homebrew, apt, etc.) without Bob managing it.
+
 ---
 
-- `bob use |nightly|stable|latest|<version-string>|<commit-hash>|`
+- `bob use |nightly|stable|latest|system|<version-string>|<commit-hash>|`
 
 `--no-install` flag will prevent bob from auto invoking install command when using `use`
 
@@ -136,7 +138,7 @@ Switch to the specified version, by default will auto-invoke install command if 
 
 ---
 
-- `bob run |nightly|stable|latest|<version-string>|<commit-hash>| [args...]`
+- `bob run |nightly|stable|latest|system|<version-string>|<commit-hash>| [args...]`
 
 Run a specific installed Neovim version with the provided arguments. `[args...]` are passed directly to the Neovim instance.
 
@@ -147,6 +149,8 @@ Example: `bob run nightly --clean my_file.txt`
 - `bob install |nightly|stable|latest|<version-string>|<commit-hash>|`
 
 Install the specified version, can also be used to update out-of-date nightly version.
+
+**Note**: The `system` version cannot be installed via Bob as it refers to your system-installed Neovim. Use your system's package manager to install or update it.
 
 ---
 
@@ -177,7 +181,7 @@ Erase any change bob ever made including Neovim installation, Neovim version dow
 
 - `bob list`
 
-List all installed and used versions.
+List all installed and used versions. If a system-installed Neovim is detected in your PATH (excluding Bob's own shim and managed versions), it will be shown as `system` with status "Available" or "Used".
 
 ---
 

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -68,6 +68,12 @@ pub async fn start(
     client: &Client,
     config: &ConfigFile,
 ) -> Result<InstallResult> {
+    if version.version_type == VersionType::System {
+        return Err(anyhow!(
+            "Cannot install 'system' version. This refers to the nvim binary available in your system PATH."
+        ));
+    }
+
     if version.version_type == VersionType::NightlyRollback {
         return Ok(InstallResult::GivenNightlyRollback);
     }
@@ -130,6 +136,9 @@ pub async fn start(
         }
         VersionType::Hash => handle_building_from_source(version, &config.config).await,
         VersionType::NightlyRollback => Ok(PostDownloadVersionType::None),
+        VersionType::System => {
+            return Err(anyhow!("Cannot install 'system' version."));
+        }
     }?;
 
     if let PostDownloadVersionType::Standard(downloaded_archive) = downloaded_archive {
@@ -413,6 +422,9 @@ async fn download_version(
         }
         VersionType::Hash => handle_building_from_source(version, config).await,
         VersionType::NightlyRollback => Ok(PostDownloadVersionType::None),
+        VersionType::System => {
+            Err(anyhow!("Cannot download 'system' version."))
+        }
     }
 }
 

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -422,9 +422,7 @@ async fn download_version(
         }
         VersionType::Hash => handle_building_from_source(version, config).await,
         VersionType::NightlyRollback => Ok(PostDownloadVersionType::None),
-        VersionType::System => {
-            Err(anyhow!("Cannot download 'system' version."))
-        }
+        VersionType::System => Err(anyhow!("Cannot download 'system' version.")),
     }
 }
 

--- a/src/handlers/list_handler.rs
+++ b/src/handlers/list_handler.rs
@@ -42,10 +42,14 @@ pub async fn start(config: Config) -> Result<()> {
 /// Represents the status of a version.
 #[derive(Debug, Clone, PartialEq)]
 enum VersionStatus {
+    /// Version is currently in use.
     Used,
-    Missing,   // System version that doesn't exist
-    Available, // System version not in use
-    Installed, // Downloaded version not in use
+    /// System version that is selected but not available on the system.
+    Missing,
+    /// System version not in use.
+    Available,
+    /// Downloaded version not in use.
+    Installed,
 }
 
 impl VersionStatus {

--- a/src/handlers/list_handler.rs
+++ b/src/handlers/list_handler.rs
@@ -28,81 +28,88 @@ use crate::{
 /// assert!(result.is_ok());
 /// ```
 pub async fn start(config: Config) -> Result<()> {
-    let downloads_dir = directories::get_downloads_directory(&config).await?;
+    let versions = collect_versions(&config).await?;
 
-    let paths: Vec<PathBuf> = fs::read_dir(downloads_dir)?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .collect();
-
-    let has_system = find_system_nvim(&config).await?.is_some();
-    let is_system_used = helpers::version::is_version_used("system", &config).await;
-    let show_system = has_system || is_system_used;
-
-    if paths.is_empty() && !show_system {
+    if versions.is_empty() {
         info!("There are no versions installed");
         return Ok(());
     }
 
-    let version_max_len = if has_rollbacks(&config).await? { 16 } else { 7 };
-    let status_max_len = 9;
-    let padding = 2;
+    render_versions_table(&versions, &config).await?;
+    Ok(())
+}
 
-    println!(
-        "┌{}┬{}┐",
-        "─".repeat(version_max_len + (padding * 2)),
-        "─".repeat(status_max_len + (padding * 2))
-    );
-    println!(
-        "│{}Version{}│{}Status{}│",
-        " ".repeat(padding),
-        " ".repeat(padding + (version_max_len - 7)),
-        " ".repeat(padding),
-        " ".repeat(padding + (status_max_len - 6))
-    );
-    println!(
-        "├{}┼{}┤",
-        "─".repeat(version_max_len + (padding * 2)),
-        "─".repeat(status_max_len + (padding * 2))
-    );
+/// Represents the status of a version.
+#[derive(Debug, Clone, PartialEq)]
+enum VersionStatus {
+    Used,
+    Missing,   // System version that doesn't exist
+    Available, // System version not in use
+    Installed, // Downloaded version not in use
+}
 
-    // Show system version
-    if show_system {
-        let version_name = "system";
-        let version_pr = (version_max_len - version_name.len()) + padding;
-        let status_pr = padding + status_max_len;
-
-        if is_system_used {
-            if has_system {
-                println!(
-                    "│{}{version_name}{}│{}{}{}│",
-                    " ".repeat(padding),
-                    " ".repeat(version_pr),
-                    " ".repeat(padding),
-                    Paint::green("Used"),
-                    " ".repeat(status_pr - 4)
-                );
-            } else {
-                println!(
-                    "│{}{version_name}{}│{}{}{}│",
-                    " ".repeat(padding),
-                    " ".repeat(version_pr),
-                    " ".repeat(padding),
-                    Paint::red("Missing"),
-                    " ".repeat(status_pr - 7)
-                );
-            }
-        } else if has_system {
-            println!(
-                "│{}{version_name}{}│{}{}{}│",
-                " ".repeat(padding),
-                " ".repeat(version_pr),
-                " ".repeat(padding),
-                Paint::cyan("Available"),
-                " ".repeat(status_pr - 9)
-            );
+impl VersionStatus {
+    fn as_str(&self) -> &str {
+        match self {
+            VersionStatus::Used => "Used",
+            VersionStatus::Missing => "Missing",
+            VersionStatus::Available => "Available",
+            VersionStatus::Installed => "Installed",
         }
     }
+
+    fn display(&self) -> Paint<&str> {
+        match self {
+            VersionStatus::Used => Paint::green(self.as_str()),
+            VersionStatus::Missing => Paint::red(self.as_str()),
+            VersionStatus::Available => Paint::cyan(self.as_str()),
+            VersionStatus::Installed => Paint::yellow(self.as_str()),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.as_str().len()
+    }
+}
+
+/// Represents a version entry with its name and status.
+#[derive(Debug)]
+struct VersionEntry {
+    name: String,
+    status: VersionStatus,
+}
+
+/// Collects all version entries with their statuses.
+async fn collect_versions(config: &Config) -> Result<Vec<VersionEntry>> {
+    let mut entries = Vec::new();
+
+    // Check for system version
+    let has_system = find_system_nvim(config).await?.is_some();
+    let is_system_used = helpers::version::is_version_used("system", config).await;
+
+    if has_system || is_system_used {
+        let status = if is_system_used {
+            if has_system {
+                VersionStatus::Used
+            } else {
+                VersionStatus::Missing
+            }
+        } else {
+            VersionStatus::Available
+        };
+
+        entries.push(VersionEntry {
+            name: "system".to_string(),
+            status,
+        });
+    }
+
+    // Collect downloaded versions
+    let downloads_dir = directories::get_downloads_directory(config).await?;
+    let paths: Vec<PathBuf> = fs::read_dir(downloads_dir)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect();
 
     for path in paths {
         if !path.is_dir() {
@@ -115,36 +122,126 @@ pub async fn start(config: Config) -> Result<()> {
             continue;
         }
 
-        let version_pr = (version_max_len - path_name.len()) + padding;
-        let status_pr = padding + status_max_len;
-
-        if helpers::version::is_version_used(path_name, &config).await {
-            println!(
-                "│{}{path_name}{}│{}{}{}│",
-                " ".repeat(padding),
-                " ".repeat(version_pr),
-                " ".repeat(padding),
-                Paint::green("Used"),
-                " ".repeat(status_pr - 4)
-            );
+        let status = if helpers::version::is_version_used(path_name, config).await {
+            VersionStatus::Used
         } else {
-            println!(
-                "│{}{path_name}{}│{}{}{}│",
-                " ".repeat(padding),
-                " ".repeat(version_pr),
-                " ".repeat(padding),
-                Paint::yellow("Installed"),
-                " ".repeat(status_pr - 9)
-            );
+            VersionStatus::Installed
+        };
+
+        entries.push(VersionEntry {
+            name: path_name.to_string(),
+            status,
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Table formatter for rendering version entries.
+struct TableFormatter {
+    version_col_width: usize,
+    status_col_width: usize,
+    padding: usize,
+}
+
+impl TableFormatter {
+    const VERSION_HEADER: &'static str = "Version";
+    const STATUS_HEADER: &'static str = "Status";
+    const PADDING: usize = 2;
+    fn new(entries: &[VersionEntry], _has_rollbacks: bool) -> Self {
+        let (max_version_len, max_status_len) =
+            entries.iter().fold((0, 0), |(max_v, max_s), entry| {
+                (max_v.max(entry.name.len()), max_s.max(entry.status.len()))
+            });
+
+        // Ensure columns are at least as wide as their headers
+        let version_col_width = max_version_len.max(Self::VERSION_HEADER.len());
+        let status_col_width = max_status_len.max(Self::STATUS_HEADER.len());
+
+        Self {
+            version_col_width,
+            status_col_width,
+            padding: Self::PADDING,
         }
     }
 
-    println!(
-        "└{}┴{}┘",
-        "─".repeat(version_max_len + (padding * 2)),
-        "─".repeat(status_max_len + (padding * 2))
-    );
+    fn print_border<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        left: &str,
+        mid: &str,
+        right: &str,
+    ) -> std::io::Result<()> {
+        writeln!(
+            writer,
+            "{}{}{}{}{}",
+            left,
+            "─".repeat(self.version_col_width + (self.padding * 2)),
+            mid,
+            "─".repeat(self.status_col_width + (self.padding * 2)),
+            right
+        )
+    }
 
+    fn print_header<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let version_padding = self.version_col_width - Self::VERSION_HEADER.len();
+        let status_padding = self.status_col_width - Self::STATUS_HEADER.len();
+
+        writeln!(
+            writer,
+            "│{}{}{}│{}{}{}│",
+            " ".repeat(self.padding),
+            Self::VERSION_HEADER,
+            " ".repeat(version_padding + self.padding),
+            " ".repeat(self.padding),
+            Self::STATUS_HEADER,
+            " ".repeat(status_padding + self.padding)
+        )
+    }
+
+    fn print_row<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        entry: &VersionEntry,
+    ) -> std::io::Result<()> {
+        let version_padding = self.version_col_width - entry.name.len();
+        let status_padding = self.status_col_width - entry.status.len();
+
+        writeln!(
+            writer,
+            "│{}{}{}│{}{}{}│",
+            " ".repeat(self.padding),
+            entry.name,
+            " ".repeat(version_padding + self.padding),
+            " ".repeat(self.padding),
+            entry.status.display(),
+            " ".repeat(status_padding + self.padding)
+        )
+    }
+
+    fn render<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        entries: &[VersionEntry],
+    ) -> std::io::Result<()> {
+        self.print_border(writer, "┌", "┬", "┐")?;
+        self.print_header(writer)?;
+        self.print_border(writer, "├", "┼", "┤")?;
+
+        for entry in entries {
+            self.print_row(writer, entry)?;
+        }
+
+        self.print_border(writer, "└", "┴", "┘")?;
+        Ok(())
+    }
+}
+
+/// Renders a table of version entries.
+async fn render_versions_table(entries: &[VersionEntry], config: &Config) -> Result<()> {
+    let has_rollbacks = has_rollbacks(config).await?;
+    let formatter = TableFormatter::new(entries, has_rollbacks);
+    formatter.render(&mut std::io::stdout(), entries)?;
     Ok(())
 }
 
@@ -208,6 +305,62 @@ fn is_version(name: &str) -> bool {
 #[cfg(test)]
 mod list_handler_is_version_tests {
     use super::*;
+
+    #[test]
+    fn test_table_formatter_basic() {
+        yansi::Paint::disable(); // Suppress colors for this test
+
+        let entries = vec![
+            super::VersionEntry {
+                name: "system".to_string(),
+                status: super::VersionStatus::Available,
+            },
+            super::VersionEntry {
+                name: "nightly".to_string(),
+                status: super::VersionStatus::Used,
+            },
+            super::VersionEntry {
+                name: "v0.11.5".to_string(),
+                status: super::VersionStatus::Installed,
+            },
+            super::VersionEntry {
+                name: "nightly-0197f13".to_string(),
+                status: super::VersionStatus::Installed,
+            },
+        ];
+        let formatter = super::TableFormatter::new(&entries, false);
+        let mut buf = Vec::new();
+        formatter.render(&mut buf, &entries).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let expected = "\
+┌───────────────────┬─────────────┐
+│  Version          │  Status     │
+├───────────────────┼─────────────┤
+│  system           │  Available  │
+│  nightly          │  Used       │
+│  v0.11.5          │  Installed  │
+│  nightly-0197f13  │  Installed  │
+└───────────────────┴─────────────┘
+";
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_table_formatter_with_rollbacks_width() {
+        let entries = vec![super::VersionEntry {
+            name: "short".to_string(),
+            status: super::VersionStatus::Used,
+        }];
+        let formatter = super::TableFormatter::new(&entries, true);
+        // Should use the max of the header or the entry length
+        assert_eq!(
+            formatter.version_col_width,
+            super::TableFormatter::VERSION_HEADER
+                .len()
+                .max("short".len())
+        );
+    }
 
     #[test]
     fn test_is_version() {

--- a/src/handlers/uninstall_handler.rs
+++ b/src/handlers/uninstall_handler.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::Config,
-    helpers::{self, directories},
+    helpers::{self, directories, version::types::VersionType},
 };
 use anyhow::{Result, anyhow};
 use dialoguer::{
@@ -48,6 +48,14 @@ pub async fn start(version: Option<&str>, config: Config) -> Result<()> {
     };
 
     let version = helpers::version::parse_version_type(&client, version).await?;
+
+    // Handle system version
+    if version.version_type == VersionType::System {
+        return Err(anyhow!(
+            "Cannot uninstall 'system' version. This refers to your system-installed Neovim. Use your system package manager (e.g., apt, brew, pacman) to uninstall it."
+        ));
+    }
+
     if helpers::version::is_version_used(&version.non_parsed_string, &config).await {
         warn!("Switch to a different version before proceeding");
         return Ok(());

--- a/src/handlers/update_handler.rs
+++ b/src/handlers/update_handler.rs
@@ -1,7 +1,8 @@
 use crate::cli::Update;
 use crate::config::ConfigFile;
 use crate::helpers::version::is_version_installed;
-use anyhow::Result;
+use crate::helpers::version::types::VersionType;
+use anyhow::{Result, anyhow};
 use reqwest::Client;
 use tracing::{info, warn};
 
@@ -81,6 +82,13 @@ pub async fn start(data: Update, client: &Client, config: ConfigFile) -> Result<
     }
 
     let version = crate::version::parse_version_type(client, &data.version.unwrap()).await?;
+
+    // Handle system version
+    if version.version_type == VersionType::System {
+        return Err(anyhow!(
+            "Cannot update 'system' version. Please use your system package manager (e.g., apt, brew, pacman) to update Neovim."
+        ));
+    }
 
     if !is_version_installed(&version.tag_name, &config.config).await? {
         warn!("{} is not installed.", version.non_parsed_string);

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,9 +1,16 @@
+/// Checksum verification utilities.
 pub mod checksum;
+/// Directory management and path resolution.
 pub mod directories;
+/// Filesystem operations and helpers.
 pub mod filesystem;
+/// Process execution and management utilities.
 pub mod processes;
+/// System-level utilities for finding Neovim installations.
 pub mod system;
+/// Archive extraction utilities.
 pub mod unarchive;
+/// Version parsing, management, and comparison utilities.
 pub mod version;
 use semver::Version;
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -2,6 +2,7 @@ pub mod checksum;
 pub mod directories;
 pub mod filesystem;
 pub mod processes;
+pub mod system;
 pub mod unarchive;
 pub mod version;
 use semver::Version;

--- a/src/helpers/system.rs
+++ b/src/helpers/system.rs
@@ -8,8 +8,7 @@ use std::os::unix::fs::PermissionsExt;
 
 /// Finds the system nvim binary in PATH that is not managed by bob.
 ///
-/// This function searches through all directories in the PATH environment variable
-/// to find an nvim executable that is neither bob's shim nor managed by bob.
+/// This is a convenience wrapper that fetches bob's directories and calls the implementation.
 ///
 /// # Arguments
 ///
@@ -31,31 +30,60 @@ pub async fn find_system_nvim(config: &Config) -> Result<Option<PathBuf>> {
     let installation_dir = directories::get_installation_directory(config).await?;
     let downloads_dir = directories::get_downloads_directory(config).await?;
 
+    Ok(find_system_nvim_impl(
+        &path_env,
+        &installation_dir,
+        &downloads_dir,
+    ))
+}
+
+/// Implementation of system nvim finder that does the actual work.
+///
+/// This function searches through all directories in the PATH environment variable
+/// to find an nvim executable that is neither bob's shim nor managed by bob.
+///
+/// # Arguments
+///
+/// * `path_env` - The PATH environment variable value to search through.
+/// * `installation_dir` - Bob's installation directory (where the shim is located).
+/// * `downloads_dir` - Bob's downloads directory (where managed versions are stored).
+///
+/// # Returns
+///
+/// * `Option<PathBuf>` - Returns `Some(PathBuf)` if a system nvim is found,
+///   `None` if no system nvim is found.
+fn find_system_nvim_impl(
+    path_env: &str,
+    installation_dir: &PathBuf,
+    downloads_dir: &PathBuf,
+) -> Option<PathBuf> {
     let nvim_name = if cfg!(windows) { "nvim.exe" } else { "nvim" };
 
     // Split PATH and search for nvim
-    for path_dir in std::env::split_paths(&path_env) {
-        // Skip if it's in bob's installation directory (the shim)
-        if path_dir.starts_with(&installation_dir) {
+    for path_dir in std::env::split_paths(path_env) {
+        // Skip path in bob's installation directory
+        if path_dir.starts_with(installation_dir) {
             continue;
         }
 
-        // Skip if it's in bob's downloads directory (managed versions)
-        if path_dir.starts_with(&downloads_dir) {
+        // Skip path in bob's downloads directory
+        if path_dir.starts_with(downloads_dir) {
             continue;
         }
 
         let nvim_path = path_dir.join(nvim_name);
+
+        // Skip path if nvim binary doesn't exist
         if !nvim_path.exists() {
             continue;
         }
 
-        // On Unix, also check if the file is executable
+        // On Unix, also check if the nvim binary is executable
         #[cfg(unix)]
         {
             if let Ok(metadata) = std::fs::metadata(&nvim_path) {
                 let permissions = metadata.permissions();
-                // Check if the file has any execute permission (user, group, or other)
+                // Check if the nvim binary has any execute permission (user, group, or other)
                 if permissions.mode() & 0o111 == 0 {
                     continue;
                 }
@@ -64,8 +92,231 @@ pub async fn find_system_nvim(config: &Config) -> Result<Option<PathBuf>> {
             }
         }
 
-        return Ok(Some(nvim_path));
+        return Some(nvim_path);
     }
 
-    Ok(None)
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Helper function to create a mock nvim executable in a directory
+    fn create_mock_nvim(dir: &std::path::Path) -> PathBuf {
+        let nvim_name = if cfg!(windows) { "nvim.exe" } else { "nvim" };
+        let nvim_path = dir.join(nvim_name);
+
+        #[cfg(unix)]
+        {
+            // Create a shell script that acts as nvim
+            fs::write(&nvim_path, "#!/bin/sh\necho 'mock nvim'\n").unwrap();
+            // Make it executable
+            let metadata = fs::metadata(&nvim_path).unwrap();
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&nvim_path, permissions).unwrap();
+        }
+
+        #[cfg(windows)]
+        {
+            // Create a batch file for Windows
+            fs::write(&nvim_path, "@echo off\r\necho mock nvim\r\n").unwrap();
+        }
+
+        nvim_path
+    }
+
+    /// Helper function to create a non-executable file
+    #[cfg(unix)]
+    fn create_non_executable_nvim(dir: &std::path::Path) -> PathBuf {
+        let nvim_path = dir.join("nvim");
+        fs::write(&nvim_path, "#!/bin/sh\necho 'mock nvim'\n").unwrap();
+        // Make it non-executable
+        let metadata = fs::metadata(&nvim_path).unwrap();
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o644);
+        fs::set_permissions(&nvim_path, permissions).unwrap();
+        nvim_path
+    }
+
+    #[test]
+    fn test_empty_path() {
+        let installation_dir = PathBuf::from("/fake/installation");
+        let downloads_dir = PathBuf::from("/fake/downloads");
+
+        let result = find_system_nvim_impl("", &installation_dir, &downloads_dir);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_finds_nvim_in_path() {
+        let _dir = TempDir::new().unwrap();
+        let nvim_path = create_mock_nvim(_dir.path());
+
+        let installation_dir = PathBuf::from("/fake/installation");
+        let downloads_dir = PathBuf::from("/fake/downloads");
+        let path_env = _dir.path().to_string_lossy().to_string();
+
+        let result = find_system_nvim_impl(&path_env, &installation_dir, &downloads_dir);
+
+        assert_eq!(result, Some(nvim_path));
+    }
+
+    #[test]
+    fn test_filters_out_installation_dir() {
+        let _installation_dir = TempDir::new().unwrap();
+        let _other_dir = TempDir::new().unwrap();
+
+        create_mock_nvim(_installation_dir.path());
+        let other_nvim_path = create_mock_nvim(_other_dir.path());
+
+        let downloads_dir = PathBuf::from("/fake/downloads");
+        let path_env = format!(
+            "{}{}{}",
+            _installation_dir.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _other_dir.path().to_string_lossy()
+        );
+
+        let result = find_system_nvim_impl(
+            &path_env,
+            &_installation_dir.path().to_path_buf(),
+            &downloads_dir,
+        );
+
+        assert_eq!(result, Some(other_nvim_path));
+    }
+
+    #[test]
+    fn test_filters_out_downloads_dir() {
+        let _downloads_dir = TempDir::new().unwrap();
+        let _other_dir = TempDir::new().unwrap();
+
+        create_mock_nvim(_downloads_dir.path());
+        let other_nvim_path = create_mock_nvim(_other_dir.path());
+
+        let installation_dir = PathBuf::from("/fake/installation");
+        let path_env = format!(
+            "{}{}{}",
+            _downloads_dir.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _other_dir.path().to_string_lossy()
+        );
+
+        let result = find_system_nvim_impl(
+            &path_env,
+            &installation_dir,
+            &_downloads_dir.path().to_path_buf(),
+        );
+
+        assert_eq!(result, Some(other_nvim_path));
+    }
+
+    #[test]
+    fn test_returns_first_valid_nvim() {
+        let _dir1 = TempDir::new().unwrap();
+        let _dir2 = TempDir::new().unwrap();
+        let _dir3 = TempDir::new().unwrap();
+
+        // Only create nvim in dir2 and dir3
+        let nvim_path2 = create_mock_nvim(_dir2.path());
+        create_mock_nvim(_dir3.path());
+
+        let installation_dir = PathBuf::from("/fake/installation");
+        let downloads_dir = PathBuf::from("/fake/downloads");
+        let path_env = format!(
+            "{}{}{}{}{}",
+            _dir1.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _dir2.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _dir3.path().to_string_lossy()
+        );
+
+        let result = find_system_nvim_impl(&path_env, &installation_dir, &downloads_dir);
+
+        assert_eq!(result, Some(nvim_path2));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_skips_non_executable_file() {
+        let _dir1 = TempDir::new().unwrap();
+        let _dir2 = TempDir::new().unwrap();
+
+        create_non_executable_nvim(_dir1.path());
+        let nvim_path2 = create_mock_nvim(_dir2.path());
+
+        let installation_dir = PathBuf::from("/fake/installation");
+        let downloads_dir = PathBuf::from("/fake/downloads");
+        let path_env = format!(
+            "{}:{}",
+            _dir1.path().to_string_lossy(),
+            _dir2.path().to_string_lossy()
+        );
+
+        let result = find_system_nvim_impl(&path_env, &installation_dir, &downloads_dir);
+
+        assert_eq!(result, Some(nvim_path2));
+    }
+
+    #[test]
+    fn test_filters_out_both_installation_and_downloads_dirs() {
+        let _installation_dir = TempDir::new().unwrap();
+        let _downloads_dir = TempDir::new().unwrap();
+        let _other_dir = TempDir::new().unwrap();
+
+        create_mock_nvim(_installation_dir.path());
+        create_mock_nvim(_downloads_dir.path());
+        let other_nvim_path = create_mock_nvim(_other_dir.path());
+
+        let path_env = format!(
+            "{}{}{}{}{}",
+            _installation_dir.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _downloads_dir.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _other_dir.path().to_string_lossy()
+        );
+
+        let result = find_system_nvim_impl(
+            &path_env,
+            &_installation_dir.path().to_path_buf(),
+            &_downloads_dir.path().to_path_buf(),
+        );
+
+        assert_eq!(result, Some(other_nvim_path));
+    }
+
+    #[test]
+    fn test_returns_none_when_only_filtered_dirs_in_path() {
+        let _installation_dir = TempDir::new().unwrap();
+        let _downloads_dir = TempDir::new().unwrap();
+
+        create_mock_nvim(_installation_dir.path());
+        create_mock_nvim(_downloads_dir.path());
+
+        let path_env = format!(
+            "{}{}{}",
+            _installation_dir.path().to_string_lossy(),
+            if cfg!(windows) { ";" } else { ":" },
+            _downloads_dir.path().to_string_lossy()
+        );
+
+        let result = find_system_nvim_impl(
+            &path_env,
+            &_installation_dir.path().to_path_buf(),
+            &_downloads_dir.path().to_path_buf(),
+        );
+
+        assert_eq!(result, None);
+    }
 }

--- a/src/helpers/system.rs
+++ b/src/helpers/system.rs
@@ -1,3 +1,9 @@
+//! System-level utilities for finding Neovim installations.
+//!
+//! This module provides functionality to locate system-installed Neovim binaries
+//! that are not managed by bob. It searches through the PATH environment variable
+//! while filtering out bob's own installation and download directories.
+
 use crate::config::Config;
 use crate::helpers::directories;
 use anyhow::Result;
@@ -5,6 +11,8 @@ use std::path::PathBuf;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+
+const PATH_ENV: &str = "PATH";
 
 /// Finds the system nvim binary in PATH that is not managed by bob.
 ///
@@ -26,7 +34,7 @@ use std::os::unix::fs::PermissionsExt;
 /// let system_nvim = find_system_nvim(&config).await?;
 /// ```
 pub async fn find_system_nvim(config: &Config) -> Result<Option<PathBuf>> {
-    let path_env = std::env::var("PATH").unwrap_or_default();
+    let path_env = std::env::var(PATH_ENV).unwrap_or_default();
     let installation_dir = directories::get_installation_directory(config).await?;
     let downloads_dir = directories::get_downloads_directory(config).await?;
 

--- a/src/helpers/system.rs
+++ b/src/helpers/system.rs
@@ -1,0 +1,71 @@
+use crate::config::Config;
+use crate::helpers::directories;
+use anyhow::Result;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// Finds the system nvim binary in PATH that is not managed by bob.
+///
+/// This function searches through all directories in the PATH environment variable
+/// to find an nvim executable that is neither bob's shim nor managed by bob.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the Config struct to get bob's directories.
+///
+/// # Returns
+///
+/// * `Result<Option<PathBuf>>` - Returns `Ok(Some(PathBuf))` if a system nvim is found,
+///   `Ok(None)` if no system nvim is found, or an error if the operation failed.
+///
+/// # Example
+///
+/// ```rust
+/// let config = Config::default();
+/// let system_nvim = find_system_nvim(&config).await?;
+/// ```
+pub async fn find_system_nvim(config: &Config) -> Result<Option<PathBuf>> {
+    let path_env = std::env::var("PATH").unwrap_or_default();
+    let installation_dir = directories::get_installation_directory(config).await?;
+    let downloads_dir = directories::get_downloads_directory(config).await?;
+
+    let nvim_name = if cfg!(windows) { "nvim.exe" } else { "nvim" };
+
+    // Split PATH and search for nvim
+    for path_dir in std::env::split_paths(&path_env) {
+        // Skip if it's in bob's installation directory (the shim)
+        if path_dir.starts_with(&installation_dir) {
+            continue;
+        }
+
+        // Skip if it's in bob's downloads directory (managed versions)
+        if path_dir.starts_with(&downloads_dir) {
+            continue;
+        }
+
+        let nvim_path = path_dir.join(nvim_name);
+        if !nvim_path.exists() {
+            continue;
+        }
+
+        // On Unix, also check if the file is executable
+        #[cfg(unix)]
+        {
+            if let Ok(metadata) = std::fs::metadata(&nvim_path) {
+                let permissions = metadata.permissions();
+                // Check if the file has any execute permission (user, group, or other)
+                if permissions.mode() & 0o111 == 0 {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+
+        return Ok(Some(nvim_path));
+    }
+
+    Ok(None)
+}

--- a/src/helpers/version/mod.rs
+++ b/src/helpers/version/mod.rs
@@ -48,6 +48,12 @@ use tracing::info;
 /// ```
 pub async fn parse_version_type(client: &Client, version: &str) -> Result<ParsedVersion> {
     match version {
+        "system" => Ok(ParsedVersion {
+            tag_name: version.to_string(),
+            version_type: VersionType::System,
+            non_parsed_string: version.to_string(),
+            semver: None,
+        }),
         "nightly" => Ok(ParsedVersion {
             tag_name: version.to_string(),
             version_type: VersionType::Nightly,

--- a/src/helpers/version/types.rs
+++ b/src/helpers/version/types.rs
@@ -63,6 +63,7 @@ pub enum VersionType {
     Nightly,
     Hash,
     NightlyRollback,
+    System,
 }
 
 /// Represents a local nightly version of the software.

--- a/src/helpers/version/types.rs
+++ b/src/helpers/version/types.rs
@@ -34,7 +34,7 @@ pub struct ParsedVersion {
 
 /// Represents the type of (a) software version.
 ///
-/// This enum is used to distinguish between different types of software versions, such as normal versions, the latest version, nightly versions, versions identified by a hash, and nightly versions that have been rolled back.
+/// This enum is used to distinguish between different types of software versions, such as normal versions, the latest version, nightly versions, versions identified by a hash, nightly versions that have been rolled back, and system versions.
 ///
 /// # Variants
 ///
@@ -43,6 +43,7 @@ pub struct ParsedVersion {
 /// * `Nightly` - Represents a nightly version.
 /// * `Hash` - Represents a version identified by a hash.
 /// * `NightlyRollback` - Represents a nightly version that has been rolled back.
+/// * `System` - Represents a system-installed version.
 ///
 /// # Example
 ///
@@ -54,15 +55,22 @@ pub struct ParsedVersion {
 ///     VersionType::Nightly => println!("This is a nightly version."),
 ///     VersionType::Hash => println!("This is a version identified by a hash."),
 ///     VersionType::NightlyRollback => println!("This is a nightly version that has been rolled back."),
+///     VersionType::System => println!("This is a system-installed version."),
 /// }
 /// ```
 #[derive(PartialEq, Eq, Debug)]
 pub enum VersionType {
+    /// Represents a normal version.
     Normal,
+    /// Represents the latest version.
     Latest,
+    /// Represents a nightly version.
     Nightly,
+    /// Represents a version identified by a hash.
     Hash,
+    /// Represents a nightly version that has been rolled back.
     NightlyRollback,
+    /// Represents a system-installed version.
     System,
 }
 


### PR DESCRIPTION
# Summary

Adds support for a `system` version in Bob, enabling users to seamlessly use their system-installed Neovim alongside Bob-managed versions. This improves user experience by removing the need for manual `PATH` adjustments and aligns Bob with the behavior of other popular version managers.

## Description

This update introduces a `system` version identifier, allowing Bob to detect and use Neovim installed via system package managers (e.g., Homebrew, apt, pacman). The `system` version acts as a passthrough, similar to the `system` option in tools like pyenv, rbenv, and fnm. Users can switch to, run, and view the status of the system version directly from Bob. Management commands (install, update, uninstall) are intentionally blocked for the `system` version, with clear guidance to use the system package manager for those actions.

### Key Features

- **New Feature:** Adds a special `system` version to Bob, allowing users to select and run the Neovim binary installed via their system package manager (e.g., Homebrew, apt, pacman) without Bob managing it directly.
- **Detection:** Automatically identifies system-installed `nvim` in `PATH`, if any, excluding Bob's shim and managed versions. On unix systems, it additionally checks if `nvim` binary is executable.
- **Command Enhancements:**
  - `bob use system` switches to the system-installed Neovim.
  - `bob run system [args]` executes the system Neovim binary.
  - `bob list` now displays the system version's status as `Available`, `Used`, or `Missing` (special case for `Used`, when system nvim is uninstalled when it is currently selected version).
- **Error Handling:** Management commands like `install`, `update`, and `uninstall` are blocked for the `system` version, with clear error messages directing users to use their package manager.
- **Refactoring:**
  - Consolidates and improves nvim execution logic and error handling.
  - list printing is refactored for maintainability.
  - install_handler is refactored to keep deepsource happy; I've tried to retain original author's intent.
- **Testing:**
  - Adds unit tests for system nvim detection and related logic.
  - Adds unit tests for list printing and formatting logic.
- **Documentation:** Updates README and inline documentation to reflect the new `system` version and its usage.

## Type of change

- [x] - New feature (non-breaking change which adds functionality)
  - [x] - Refactor (non-breaking change which improves code quality and maintainability)
  - [x] - Test improvement (better coverage and reliability)

## Checklist

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `cargo fmt`
- [x] - No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)

2. Best-Effort

- [x] - My changes generate no new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

3. Documentation

- [x] - Any documentation that relates to this PR has been updated

4. Tests

- [x] - I have added tests that prove my fix is effective or that my feature works
- [x] - New and existing unit tests pass locally with my changes

5. Dependencies

- [x] - Any dependent changes have been merged and published in downstream modules

</p>
</details>
