### PR TITLE
Deprecate OpenSSL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,169 +1,192 @@
 name: Continuous Deployment
 
 on:
-    push:
-        tags:
-            - "v*.*.*"
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
-    check-version:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-            - name: Check version
-              id: check_version
-              run: |
-                  VERSION=v$(grep '^version =' Cargo.toml | cut -d '"' -f 2 | head -n 1)
-                  GIT_TAG_VERSION=${{ github.ref }} 
-                  GIT_TAG_VERSION=${GIT_TAG_VERSION#refs/tags/}
-                  if [[ "$VERSION" != "$GIT_TAG_VERSION" ]]; then
-                    echo "Version in Cargo.toml ($VERSION) does not match pushed tag ($GIT_TAG_VERSION)"
-                    exit 1
-                  fi
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check version
+        id: check_version
+        run: |
+          VERSION=v$(grep '^version =' Cargo.toml | cut -d '"' -f 2 | head -n 1)
+          GIT_TAG_VERSION=${{ github.ref }}
+          GIT_TAG_VERSION=${GIT_TAG_VERSION#refs/tags/}
+          if [[ "$VERSION" != "$GIT_TAG_VERSION" ]]; then
+            echo "Version in Cargo.toml ($VERSION) does not match pushed tag ($GIT_TAG_VERSION)"
+            exit 1
+          fi
 
-    build:
-        needs: [check-version]
-        strategy:
-            matrix:
-                os:
-                    - { NAME: linux, OS: ubuntu-latest, ARCH: x86_64, PATH: target/optimized/bob, TARGET: "" }
-                    - { NAME: linux, OS: ubuntu-24.04-arm, ARCH: arm, PATH: target/optimized/bob, TARGET: "" }
-                    - { NAME: macos, OS: macos-latest, ARCH: x86_64, PATH: target/x86_64-apple-darwin/optimized/bob, TARGET: "x86_64-apple-darwin" }
-                    - { NAME: windows, OS: windows-latest, ARCH: x86_64, PATH: build, TARGET: "" }
-                    - { NAME: macos, OS: macos-latest, ARCH: arm, PATH: target/optimized/bob, TARGET: "" }
-                tls:
-                    - { NAME: Rustls, SUFFIX: "", ARGS: "" }
-                    - { NAME: OpenSSL, SUFFIX: "-openssl", ARGS: "--no-default-features --features native-tls" }
-        runs-on: ${{matrix.os.OS}}
-        steps:
-            - uses: actions/checkout@v4
-            - name: Install Rust
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
-            - name: Add Rust target for cross-compilation
-              if: matrix.os.TARGET != ''
-              run: rustup target add ${{ matrix.os.TARGET }}
-            - name: Install OpenSSL libraries
-              run: sudo apt update && sudo apt install libssl-dev
-              if: matrix.os.OS == 'ubuntu-latest' && matrix.tls.NAME == 'OpenSSL'
-            - uses: Swatinem/rust-cache@v1
-            - name: Build Bob
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --locked --profile optimized ${{ matrix.tls.ARGS }} ${{ matrix.os.TARGET != '' && format('--target {0}', matrix.os.TARGET) || '' }}
-            - name: Install AppImage tools
-              if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
-              run: |
-                  sudo apt update && sudo apt install -y libfuse2 # Needed by AppImage/linuxdeploy
-                  
-                  # Determine the correct architecture for linuxdeploy download
-                  DOWNLOAD_ARCH=${{ matrix.os.ARCH }}
-                  if [[ "${{ matrix.os.ARCH }}" == "arm" ]]; then
-                    DOWNLOAD_ARCH="aarch64"
-                  fi
-                  
-                  echo "Downloading linuxdeploy tools for architecture: $DOWNLOAD_ARCH"
-                  wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy
-                  wget -c "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy-plugin-appimage
-                  chmod +x linuxdeploy linuxdeploy-plugin-appimage
+  build:
+    needs: [check-version]
+    strategy:
+      matrix:
+        os:
+          - {
+              NAME: linux,
+              OS: ubuntu-latest,
+              ARCH: x86_64,
+              PATH: target/optimized/bob,
+              TARGET: "",
+            }
+          - {
+              NAME: linux,
+              OS: ubuntu-24.04-arm,
+              ARCH: arm,
+              PATH: target/optimized/bob,
+              TARGET: "",
+            }
+          - {
+              NAME: macos,
+              OS: macos-latest,
+              ARCH: x86_64,
+              PATH: target/x86_64-apple-darwin/optimized/bob,
+              TARGET: "x86_64-apple-darwin",
+            }
+          - {
+              NAME: windows,
+              OS: windows-latest,
+              ARCH: x86_64,
+              PATH: build,
+              TARGET: "",
+            }
+          - {
+              NAME: macos,
+              OS: macos-latest,
+              ARCH: arm,
+              PATH: target/optimized/bob,
+              TARGET: "",
+            }
+    runs-on: ${{matrix.os.OS}}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Add Rust target for cross-compilation
+        if: matrix.os.TARGET != ''
+        run: rustup target add ${{ matrix.os.TARGET }}
+      - uses: Swatinem/rust-cache@v1
+      - name: Build Bob
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --locked --profile optimized ${{ matrix.os.TARGET != '' && format('--target {0}', matrix.os.TARGET) || '' }}
+      - name: Install AppImage tools
+        if: matrix.os.NAME == 'linux'
+        run: |
+          sudo apt update && sudo apt install -y libfuse2 # Needed by AppImage/linuxdeploy
 
-            - name: Prepare AppDir
-              if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
-              run: |
-                  mkdir -p AppDir/usr/bin AppDir/usr/share/icons/hicolor/256x256/apps AppDir/usr/share/applications
-                  cp target/optimized/bob AppDir/usr/bin/
-                  cp resources/bob-icon.png AppDir/usr/share/icons/hicolor/256x256/apps/bob.png
-                  cat <<EOF > AppDir/bob.desktop
-                  [Desktop Entry]
-                  Name=Bob Neovim Manager
-                  Exec=bob
-                  Icon=bob
-                  Type=Application
-                  Categories=Utility;Development;
-                  Comment=A cross-platform Neovim version manager
-                  EOF
-                  cp AppDir/bob.desktop AppDir/usr/share/applications/
-                  
-                  # Verify the file exists right before linuxdeploy
-                  ls -l AppDir/usr/bin/bob 
+          # Determine the correct architecture for linuxdeploy download
+          DOWNLOAD_ARCH=${{ matrix.os.ARCH }}
+          if [[ "${{ matrix.os.ARCH }}" == "arm" ]]; then
+            DOWNLOAD_ARCH="aarch64"
+          fi
 
-                  export UPD_INFO="gh-releases-zsync|Matsuuu|bob|latest|bob-${{ matrix.os.ARCH }}.AppImage.zsync"
-                  export OUTPUT="bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage"
-                  
-                  # Change --executable path to be relative to CWD
-                  ./linuxdeploy --appdir AppDir --executable AppDir/usr/bin/bob --desktop-file AppDir/bob.desktop --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/bob.png --output appimage
+          echo "Downloading linuxdeploy tools for architecture: $DOWNLOAD_ARCH"
+          wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy
+          wget -c "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy-plugin-appimage
+          chmod +x linuxdeploy linuxdeploy-plugin-appimage
 
+      - name: Prepare AppDir
+        if: matrix.os.NAME == 'linux'
+        run: |
+          mkdir -p AppDir/usr/bin AppDir/usr/share/icons/hicolor/256x256/apps AppDir/usr/share/applications
+          cp target/optimized/bob AppDir/usr/bin/
+          cp resources/bob-icon.png AppDir/usr/share/icons/hicolor/256x256/apps/bob.png
+          cat <<EOF > AppDir/bob.desktop
+          [Desktop Entry]
+          Name=Bob Neovim Manager
+          Exec=bob
+          Icon=bob
+          Type=Application
+          Categories=Utility;Development;
+          Comment=A cross-platform Neovim version manager
+          EOF
+          cp AppDir/bob.desktop AppDir/usr/share/applications/
 
-            - name: Setup Bob build directory
-              run: |
-                  mkdir build
-                  copy .\\bin\\vcruntime140.dll .\\build
-                  copy .\\target\\optimized\\bob.exe .\\build
-              if: matrix.os.OS == 'windows-latest'
-            - name: Upload Bob binary
-              uses: actions/upload-artifact@v4
-              with:
-                  name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}"
-                  path: ${{ matrix.os.PATH }}
-                  if-no-files-found: error
-            - name: Upload Bob AppImage
-              if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
-              uses: actions/upload-artifact@v4
-              with:
-                  name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}-appimage"
-                  path: "bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage*" 
-                  if-no-files-found: error
-                  retention-days: 7
+          # Verify the file exists right before linuxdeploy
+          ls -l AppDir/usr/bin/bob
 
-    github-release:
-        needs: [build]
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
-            - name: Download artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  path: artifacts
-            - name: Prepare Release Assets (Zip binaries, keep AppImages separate)
-              run: |
-                  cd artifacts
-                  # Zip directories (binaries)
-                  find . -mindepth 1 -maxdepth 1 -type d -print0 | while IFS= read -r -d $'\0' dir; do
-                    base=$(basename "$dir")
-                    zip -r "${base}.zip" "$dir"
-                    rm -r "$dir" # Remove original directory after zipping
-                  done
-                  # Move AppImages and zsync files out of subdirectories if they exist
-                  find . -mindepth 2 -name '*.AppImage*' -exec mv {} . \;
-                  # Clean up any remaining empty directories from AppImage artifacts
-                  find . -mindepth 1 -maxdepth 1 -type d -empty -delete
-                  echo "Prepared assets:"
-                  ls -l
-            - name: Release
-              uses: softprops/action-gh-release@v1
-              if: startsWith(github.ref, 'refs/tags/')
-              with:
-                  generate_release_notes: true
-                  files: |
-                      ./artifacts/*
+          export UPD_INFO="gh-releases-zsync|Matsuuu|bob|latest|bob-${{ matrix.os.ARCH }}.AppImage.zsync"
+          export OUTPUT="bob-${{ matrix.os.ARCH }}.AppImage"
 
-    publish-cargo:
-        needs: github-release
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  override: true
-            - uses: katyo/publish-crates@v2
-              with:
-                  registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # Change --executable path to be relative to CWD
+          ./linuxdeploy --appdir AppDir --executable AppDir/usr/bin/bob --desktop-file AppDir/bob.desktop --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/bob.png --output appimage
+
+      - name: Setup Bob build directory
+        run: |
+          mkdir build
+          copy .\\bin\\vcruntime140.dll .\\build
+          copy .\\target\\optimized\\bob.exe .\\build
+        if: matrix.os.OS == 'windows-latest'
+      - name: Upload Bob binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}"
+          path: ${{ matrix.os.PATH }}
+          if-no-files-found: error
+      - name: Upload Bob AppImage
+        if: matrix.os.NAME == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}-appimage"
+          path: "bob-${{ matrix.os.ARCH }}.AppImage*"
+          if-no-files-found: error
+          retention-days: 7
+
+  github-release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Prepare Release Assets (Zip binaries, keep AppImages separate)
+        run: |
+          cd artifacts
+          # Zip directories (binaries)
+          find . -mindepth 1 -maxdepth 1 -type d -print0 | while IFS= read -r -d $'\0' dir; do
+            base=$(basename "$dir")
+            zip -r "${base}.zip" "$dir"
+            rm -r "$dir" # Remove original directory after zipping
+          done
+          # Move AppImages and zsync files out of subdirectories if they exist
+          find . -mindepth 2 -name '*.AppImage*' -exec mv {} . \;
+          # Clean up any remaining empty directories from AppImage artifacts
+          find . -mindepth 1 -maxdepth 1 -type d -empty -delete
+          echo "Prepared assets:"
+          ls -l
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            ./artifacts/*
+
+  publish-cargo:
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,213 +2,213 @@ name: Continuous Integration
 on: [push, pull_request]
 
 jobs:
-    clippy:
-        strategy:
-            matrix:
-                os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
-        runs-on: ${{matrix.os}}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
-            - name: Check the lints
-              uses: actions-rs/cargo@v1
-              with:
-                  command: clippy
-                  args: --verbose -- -D warnings
+  clippy:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Check the lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
 
-    test:
-        strategy:
-            matrix:
-                os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
-        runs-on: ${{matrix.os}}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
-            - name: Run the tests
-              uses: actions-rs/cargo@v1
-              with:
-                  command: test
-                  args: --locked --verbose
+  test:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run the tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --locked
 
-    formatting:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
-            - name: Check the formatting
-              uses: actions-rs/cargo@v1
-              with:
-                  command: fmt
-                  args: --all -- --check --verbose
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Check the formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
-    security_audit:
-      runs-on: ubuntu-latest
-      steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
-            - name: Install cargo-audit
-              uses: actions-rs/cargo@v1
-              with:
-                  command: install
-                  args: cargo-audit
-            - name: Run security audit
-              uses: actions-rs/cargo@v1
-              with:
-                  command: audit
-                  args: --deny warnings
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Install cargo-audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-audit
+      - name: Run security audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+          args: --deny warnings
 
-    build:
-        needs: [clippy, formatting, test, security_audit]
-        strategy:
-            matrix:
-                os:
-                    - {
-                          NAME: linux,
-                          OS: ubuntu-latest,
-                          ARCH: x86_64,
-                          PATH: target/optimized/bob,
-                          TARGET: "",
-                      }
-                    - {
-                          NAME: linux,
-                          OS: ubuntu-24.04-arm,
-                          ARCH: arm,
-                          PATH: target/optimized/bob,
-                          TARGET: "",
-                      }
-                    - {
-                          NAME: macos,
-                          OS: macos-latest,
-                          ARCH: x86_64,
-                          PATH: target/x86_64-apple-darwin/optimized/bob,
-                          TARGET: "x86_64-apple-darwin",
-                      }
-                    - {
-                          NAME: windows,
-                          OS: windows-latest,
-                          ARCH: x86_64,
-                          PATH: build,
-                          TARGET: "",
-                      }
-                    - {
-                          NAME: macos,
-                          OS: macos-latest,
-                          ARCH: arm,
-                          PATH: target/optimized/bob,
-                          TARGET: "",
-                      }
-                tls:
-                    - { NAME: Rustls, SUFFIX: "", ARGS: "" }
-                    - {
-                          NAME: OpenSSL,
-                          SUFFIX: "-openssl",
-                          ARGS: "--no-default-features --features native-tls",
-                      }
-        runs-on: ${{matrix.os.OS}}
-        steps:
-            - uses: actions/checkout@v4
-            - name: Install Rust
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
-            - name: Add Rust target for cross-compilation
-              if: matrix.os.TARGET != ''
-              run: rustup target add ${{ matrix.os.TARGET }}
-            - name: Install OpenSSL libraries
-              run: sudo apt update && sudo apt install libssl-dev
-              if: matrix.os.OS == 'ubuntu-latest' && matrix.tls.NAME == 'OpenSSL'
-            - uses: Swatinem/rust-cache@v1
-            - name: Build Bob
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --locked --profile optimized ${{ matrix.tls.ARGS }} ${{ matrix.os.TARGET != '' && format('--target {0}', matrix.os.TARGET) || '' }}
-            - name: Install AppImage tools
-              if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
-              run: |
-                  sudo apt update && sudo apt install -y libfuse2 # Needed by AppImage/linuxdeploy
-                  
-                  # Determine the correct architecture for linuxdeploy download
-                  DOWNLOAD_ARCH=${{ matrix.os.ARCH }}
-                  if [[ "${{ matrix.os.ARCH }}" == "arm" ]]; then
-                    DOWNLOAD_ARCH="aarch64"
-                  fi
-                  
-                  echo "Downloading linuxdeploy tools for architecture: $DOWNLOAD_ARCH"
-                  wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy
-                  wget -c "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy-plugin-appimage
-                  chmod +x linuxdeploy linuxdeploy-plugin-appimage
+  build:
+    needs: [clippy, formatting, test, security_audit]
+    strategy:
+      matrix:
+        os:
+          - {
+              NAME: linux,
+              OS: ubuntu-latest,
+              ARCH: x86_64,
+              PATH: target/optimized/bob,
+              TARGET: "",
+            }
+          - {
+              NAME: linux,
+              OS: ubuntu-24.04-arm,
+              ARCH: arm,
+              PATH: target/optimized/bob,
+              TARGET: "",
+            }
+          - {
+              NAME: macos,
+              OS: macos-latest,
+              ARCH: x86_64,
+              PATH: target/x86_64-apple-darwin/optimized/bob,
+              TARGET: "x86_64-apple-darwin",
+            }
+          - {
+              NAME: windows,
+              OS: windows-latest,
+              ARCH: x86_64,
+              PATH: build,
+              TARGET: "",
+            }
+          - {
+              NAME: macos,
+              OS: macos-latest,
+              ARCH: arm,
+              PATH: target/optimized/bob,
+              TARGET: "",
+            }
+        tls:
+          - { NAME: Rustls, SUFFIX: "", ARGS: "" }
+          - {
+              NAME: OpenSSL,
+              SUFFIX: "-openssl",
+              ARGS: "--no-default-features --features native-tls",
+            }
+    runs-on: ${{matrix.os.OS}}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Add Rust target for cross-compilation
+        if: matrix.os.TARGET != ''
+        run: rustup target add ${{ matrix.os.TARGET }}
+      - name: Install OpenSSL libraries
+        run: sudo apt update && sudo apt install libssl-dev
+        if: matrix.os.OS == 'ubuntu-latest' && matrix.tls.NAME == 'OpenSSL'
+      - uses: Swatinem/rust-cache@v1
+      - name: Build Bob
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --locked --profile optimized ${{ matrix.tls.ARGS }} ${{ matrix.os.TARGET != '' && format('--target {0}', matrix.os.TARGET) || '' }}
+      - name: Install AppImage tools
+        if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
+        run: |
+          sudo apt update && sudo apt install -y libfuse2 # Needed by AppImage/linuxdeploy
 
-            - name: Prepare AppDir
-              if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
-              run: |
-                  mkdir -p AppDir/usr/bin AppDir/usr/share/icons/hicolor/256x256/apps AppDir/usr/share/applications
-                  cp target/optimized/bob AppDir/usr/bin/
-                  cp resources/bob-icon.png AppDir/usr/share/icons/hicolor/256x256/apps/bob.png
-                  cat <<EOF > AppDir/bob.desktop
-                  [Desktop Entry]
-                  Name=Bob Neovim Manager
-                  Exec=bob
-                  Icon=bob
-                  Type=Application
-                  Categories=Utility;Development;
-                  Comment=A cross-platform Neovim version manager
-                  EOF
-                  cp AppDir/bob.desktop AppDir/usr/share/applications/
-                  
-                  # Verify the file exists right before linuxdeploy
-                  ls -l AppDir/usr/bin/bob 
+          # Determine the correct architecture for linuxdeploy download
+          DOWNLOAD_ARCH=${{ matrix.os.ARCH }}
+          if [[ "${{ matrix.os.ARCH }}" == "arm" ]]; then
+            DOWNLOAD_ARCH="aarch64"
+          fi
 
-                  export UPD_INFO="gh-releases-zsync|Matsuuu|bob|latest|bob-${{ matrix.os.ARCH }}.AppImage.zsync"
-                  export OUTPUT="bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage"
-                  
-                  # Change --executable path to be relative to CWD
-                  ./linuxdeploy --appdir AppDir --executable AppDir/usr/bin/bob --desktop-file AppDir/bob.desktop --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/bob.png --output appimage
+          echo "Downloading linuxdeploy tools for architecture: $DOWNLOAD_ARCH"
+          wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy
+          wget -c "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-$DOWNLOAD_ARCH.AppImage" -O linuxdeploy-plugin-appimage
+          chmod +x linuxdeploy linuxdeploy-plugin-appimage
 
-            - name: Setup Bob build directory
-              run: |
-                  mkdir build
-                  copy .\\bin\\vcruntime140.dll .\\build
-                  copy .\\target\\optimized\\bob.exe .\\build
-              if: matrix.os.OS == 'windows-latest'
-            - name: Upload Bob binary
-              uses: actions/upload-artifact@v4
-              with:
-                  name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}"
-                  path: ${{ matrix.os.PATH }}
-                  if-no-files-found: error
-                  retention-days: 7
-            - name: Upload Bob AppImage
-              if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
-              uses: actions/upload-artifact@v4
-              with:
-                  name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}-appimage"
-                  path: "bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage*" 
-                  if-no-files-found: error
-                  retention-days: 7
+      - name: Prepare AppDir
+        if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
+        run: |
+          mkdir -p AppDir/usr/bin AppDir/usr/share/icons/hicolor/256x256/apps AppDir/usr/share/applications
+          cp target/optimized/bob AppDir/usr/bin/
+          cp resources/bob-icon.png AppDir/usr/share/icons/hicolor/256x256/apps/bob.png
+          cat <<EOF > AppDir/bob.desktop
+          [Desktop Entry]
+          Name=Bob Neovim Manager
+          Exec=bob
+          Icon=bob
+          Type=Application
+          Categories=Utility;Development;
+          Comment=A cross-platform Neovim version manager
+          EOF
+          cp AppDir/bob.desktop AppDir/usr/share/applications/
+
+          # Verify the file exists right before linuxdeploy
+          ls -l AppDir/usr/bin/bob
+
+          export UPD_INFO="gh-releases-zsync|Matsuuu|bob|latest|bob-${{ matrix.os.ARCH }}.AppImage.zsync"
+          export OUTPUT="bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage"
+
+          # Change --executable path to be relative to CWD
+          ./linuxdeploy --appdir AppDir --executable AppDir/usr/bin/bob --desktop-file AppDir/bob.desktop --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/bob.png --output appimage
+
+      - name: Setup Bob build directory
+        run: |
+          mkdir build
+          copy .\\bin\\vcruntime140.dll .\\build
+          copy .\\target\\optimized\\bob.exe .\\build
+        if: matrix.os.OS == 'windows-latest'
+      - name: Upload Bob binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}"
+          path: ${{ matrix.os.PATH }}
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload Bob AppImage
+        if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}-appimage"
+          path: "bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage*"
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets -- -D warnings
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,6 @@ jobs:
               PATH: target/optimized/bob,
               TARGET: "",
             }
-        tls:
-          - { NAME: Rustls, SUFFIX: "", ARGS: "" }
-          - {
-              NAME: OpenSSL,
-              SUFFIX: "-openssl",
-              ARGS: "--no-default-features --features native-tls",
-            }
     runs-on: ${{matrix.os.OS}}
     steps:
       - uses: actions/checkout@v4
@@ -140,17 +133,14 @@ jobs:
       - name: Add Rust target for cross-compilation
         if: matrix.os.TARGET != ''
         run: rustup target add ${{ matrix.os.TARGET }}
-      - name: Install OpenSSL libraries
-        run: sudo apt update && sudo apt install libssl-dev
-        if: matrix.os.OS == 'ubuntu-latest' && matrix.tls.NAME == 'OpenSSL'
       - uses: Swatinem/rust-cache@v1
       - name: Build Bob
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --locked --profile optimized ${{ matrix.tls.ARGS }} ${{ matrix.os.TARGET != '' && format('--target {0}', matrix.os.TARGET) || '' }}
+          args: --locked --profile optimized ${{ matrix.os.TARGET != '' && format('--target {0}', matrix.os.TARGET) || '' }}
       - name: Install AppImage tools
-        if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
+        if: matrix.os.NAME == 'linux'
         run: |
           sudo apt update && sudo apt install -y libfuse2 # Needed by AppImage/linuxdeploy
 
@@ -166,7 +156,7 @@ jobs:
           chmod +x linuxdeploy linuxdeploy-plugin-appimage
 
       - name: Prepare AppDir
-        if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
+        if: matrix.os.NAME == 'linux'
         run: |
           mkdir -p AppDir/usr/bin AppDir/usr/share/icons/hicolor/256x256/apps AppDir/usr/share/applications
           cp target/optimized/bob AppDir/usr/bin/
@@ -186,7 +176,7 @@ jobs:
           ls -l AppDir/usr/bin/bob
 
           export UPD_INFO="gh-releases-zsync|Matsuuu|bob|latest|bob-${{ matrix.os.ARCH }}.AppImage.zsync"
-          export OUTPUT="bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage"
+          export OUTPUT="bob-${{ matrix.os.ARCH }}.AppImage"
 
           # Change --executable path to be relative to CWD
           ./linuxdeploy --appdir AppDir --executable AppDir/usr/bin/bob --desktop-file AppDir/bob.desktop --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/bob.png --output appimage
@@ -200,15 +190,15 @@ jobs:
       - name: Upload Bob binary
         uses: actions/upload-artifact@v4
         with:
-          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}"
+          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}"
           path: ${{ matrix.os.PATH }}
           if-no-files-found: error
           retention-days: 7
       - name: Upload Bob AppImage
-        if: matrix.os.NAME == 'linux' && matrix.tls.NAME == 'Rustls'
+        if: matrix.os.NAME == 'linux'
         uses: actions/upload-artifact@v4
         with:
-          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}-appimage"
-          path: "bob-${{ matrix.os.ARCH }}${{ matrix.tls.SUFFIX }}.AppImage*"
+          name: "bob-${{ matrix.os.NAME }}-${{ matrix.os.ARCH }}-appimage"
+          path: "bob-${{ matrix.os.ARCH }}.AppImage*"
           if-no-files-found: error
           retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ Thanks for wanting to contribute! Bob is community-driven and we appreciate all 
 
 - Rust toolchain ([rustup](https://rustup.rs/))
 - Git
-- OpenSSL (optional, for `native-tls` feature)
 
 ### Optional: Building Neovim
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,16 +371,6 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -547,12 +537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,21 +563,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -797,23 +766,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1152,23 +1104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,48 +1180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1583,11 +1480,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1599,7 +1494,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -1610,7 +1504,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1669,7 +1562,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -1722,25 +1615,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1981,19 +1861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,16 +1979,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2357,12 +2214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,15 +2332,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.61"
+version = "4.5.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
+checksum = "4c0da80818b2d95eca9aa614a30783e42f62bf5fdfee24e68cfb960b071ba8d1"
 dependencies = [
  "clap",
 ]
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -550,15 +550,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "flate2"
-version = "1.1.7"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -865,9 +865,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -935,7 +935,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console 0.16.1",
+ "console 0.16.2",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -959,9 +959,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -975,9 +975,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -1013,13 +1013,13 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
 dependencies = [
  "winapi",
 ]
@@ -1181,9 +1181,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "option-ext"
@@ -1209,7 +1209,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -1250,9 +1250,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "potential_utf"
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1426,6 +1426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,9 +1476,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -1528,9 +1537,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -1555,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1567,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1594,9 +1603,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "schannel"
@@ -1674,15 +1683,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1739,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1751,18 +1760,19 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
@@ -2062,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2092,9 +2102,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2114,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2875,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2946,6 +2956,12 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9747e91771f56fd7893e1164abd78febd14a670ceec257caad15e051de35f06"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,6 @@ license = "MIT"
 repository = "https://github.com/MordechaiHadad/bob"
 rust-version = "1.85"
 
-[features]
-default = ["rustls-tls"]
-native-tls = ["reqwest/default-tls"]
-rustls-tls = ["reqwest/rustls-tls-native-roots"]
-
 [dependencies]
 anyhow = "1.0.52"
 cfg-if = "1.0"
@@ -60,7 +55,7 @@ optional = false
 
 [dependencies.reqwest]
 version = "0.12"
-features = ["stream", "rustls-tls"]
+features = ["stream", "rustls-tls-native-roots"]
 optional = false
 default-features = false
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Bob is a cross-platform and easy-to-use Neovim version manager, allowing for eas
 
 - **2024-05-17**: Support for `nvim-qt` is now deprecated as Neovim no longer supports it in newer releases. If you're currently using `nvim-qt`, we recommend switching to a different Neovim GUI or using Neovim in the terminal. Please refer to the Neovim documentation for more information on supported GUIs.
 - **2024-05-19**: Important notice for users who built Neovim from source using a commit hash before the newest Bob version: Due to recent changes in Bob, these versions will need to be rebuilt. Alternatively, you can manually add a file named `full-hash.txt` at the root of the directory. This file should contain the full hash of the commit used to build Neovim. This change ensures better tracking and management of versions built from source. We apologize for any inconvenience and appreciate your understanding.
+- **2025-12-30**: OpenSSL builds are now fully deprecated due to redundancy and maintenance overhead. Please switch to the standard bob builds.
 
 ## 📦 Requirements
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Make sure you don't have Neovim already installed via other ways e.g. a package 
 
 Make sure [rustup](https://www.rust-lang.org/tools/install) is installed.
 
-(Optional) `openssl` if built with `native-tls` feature.
-
 #### Building Neovim
 
 For further information refer to the [Neovim wiki](https://github.com/neovim/neovim/wiki/Building-Neovim#build-prerequisites).
@@ -96,7 +94,7 @@ Each script downloads the latest release for your platform and links the `bob` b
 
 ### Install from releases
 
-1. Download the bob release suitable for your platform: either `bob-{platform}-x86_64.zip` for the standard version or `bob-{platform}-x86_64-openssl.zip` for the OpenSSL version.
+1. Download the bob release suitable for your platform `bob-{platform}-x86_64.zip`
 2. Unzip it
 3. Run it with `bob`
 4. Linux users can also grab the AppImage artifacts (e.g., `bob-linux-x86_64-appimage.zip` or `bob-linux-arm-appimage.zip`) and follow the same unpack-and-run steps.
@@ -108,14 +106,7 @@ Each script downloads the latest release for your platform and links the `bob` b
 
 ### Install from source
 
-For the standard version:
-
 1. `cargo install --git https://github.com/MordechaiHadad/bob.git`
-2. Run Bob with `bob`
-
-For the OpenSSL version:
-
-1. To install, include the `--no-default-features --features native-tls` flags with your command:  `cargo install --git https://github.com/MordechaiHadad/bob.git --no-default-features --features native-tls`
 2. Run Bob with `bob`
 
 ### Install from crates.io


### PR DESCRIPTION
# Summary

- Fixes #370 

Deprecates openssl releases completely.

## Description

I removed openssl

## Type of change

- [x] - New feature (non-breaking change which adds functionality)
- [x] - Documentation update

## Checklist

<details>
  <summary>
    Checklist tick-boxes
  </summary>
<p>

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `cargo fmt`
- [x] - No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)

2. Best-Effort

- [x] - My changes generate no new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

3. Documentation

- [x] - Any documentation that relates to this PR has been updated
    or will be updated in a PR (Link here: )(if applicable)

</p>
</details>
