### PR TITLE
feat: support use fork as version

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ A version-string can either be `vx.x.x` or `x.x.x` examples: `v0.6.1` and `0.6.0
 
 ---
 
-- `bob use |nightly|stable|latest|<version-string>|<commit-hash>|`
+- `bob use |nightly|stable|latest|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|`
 
 `--no-install` flag will prevent bob from auto invoking install command when using `use`
 
@@ -136,7 +136,7 @@ Switch to the specified version, by default will auto-invoke install command if 
 
 ---
 
-- `bob run |nightly|stable|latest|<version-string>|<commit-hash>| [args...]`
+- `bob run |nightly|stable|latest|<version-string>|<commit-hash>|<owner>/<repo>@<ref>| [args...]`
 
 Run a specific installed Neovim version with the provided arguments. `[args...]` are passed directly to the Neovim instance.
 
@@ -144,7 +144,7 @@ Example: `bob run nightly --clean my_file.txt`
 
 ---
 
-- `bob install |nightly|stable|latest|<version-string>|<commit-hash>|`
+- `bob install |nightly|stable|latest|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|`
 
 Install the specified version, can also be used to update out-of-date nightly version.
 
@@ -156,7 +156,7 @@ If Config::version_sync_file_location is set, the version in that file will be p
 
 ---
 
-- `bob uninstall [|nightly|stable|latest|<version-string>|<commit-hash>|]`
+- `bob uninstall [|nightly|stable|latest|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|]`
 
 Uninstall the specified version. If no version is specified a prompt is used to select all the versions
 to be uninstalled.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,6 +273,9 @@ pub async fn start(config: ConfigFile) -> Result<()> {
                 InstallResult::NightlyIsUpdated => {
                     info!("Nightly up to date!");
                 }
+                InstallResult::ForkIsUpdated => {
+                    info!("{tag_name} is up to date!");
+                }
                 InstallResult::GivenNightlyRollback => (),
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,9 +58,10 @@ enum Cli {
     /// Switch to the specified version, by default will auto-invoke
     /// install command if the version is not installed already
     Use {
-        /// Version to switch to |nightly|stable|<version-string>|<commit-hash>|
+        /// Version to switch to |nightly|stable|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|
         ///
         /// A version-string can either be `vx.x.x` or `x.x.x` examples: `v0.6.1` and `0.6.0`
+        /// Fork format: <owner>/<repo>@<ref> where <ref> is a branch, tag, or commit (e.g., user/neovim@my-branch)
         version: String,
 
         /// Whether not to auto-invoke install command
@@ -71,9 +72,10 @@ enum Cli {
     /// Install the specified version, can also be used to update
     /// out-of-date nightly version
     Install {
-        /// Version to be installed |nightly|stable|<version-string>|<commit-hash>|
+        /// Version to be installed |nightly|stable|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|
         ///
         /// A version-string can either be `vx.x.x` or `x.x.x` examples: `v0.6.1` and `0.6.0`
+        /// Fork format: <owner>/<repo>@<ref> where <ref> is a branch, tag, or commit (e.g., user/neovim@feature-x)
         version: String,
     },
 
@@ -84,9 +86,10 @@ enum Cli {
     /// Uninstall the specified version
     #[clap(alias = "remove", visible_alias = "rm")]
     Uninstall {
-        /// Optional Version to be uninstalled |nightly|stable|<version-string>|<commit-hash>|
+        /// Optional Version to be uninstalled |nightly|stable|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|
         ///
         /// A version-string can either be `vx.x.x` or `x.x.x` examples: `v0.6.1` and `0.6.0`
+        /// Fork format: <owner>/<repo>@<ref> where <ref> is a branch, tag, or commit (e.g., user/neovim@feature-x)
         ///
         /// If no Version is provided a prompt is used to select the versions to be uninstalled
         version: Option<String>,
@@ -117,7 +120,9 @@ enum Cli {
 
     #[clap(trailing_var_arg = true)]
     Run {
-        /// Optional version to run |nightly|stable|<version-string>|<commit-hash>|
+        /// Optional version to run |nightly|stable|<version-string>|<commit-hash>|<owner>/<repo>@<ref>|
+        ///
+        /// Fork format: <owner>/<repo>@<ref> where <ref> is a branch, tag, or commit (e.g., user/neovim@feature-x)
         version: String,
 
         /// Arguments to pass to Neovim (flags, files, commands, etc.)

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -54,6 +54,20 @@ pub static ENVIRONMENT_VAR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\$([A-Z_]+)").expect("Failed to compile static ENVIRONMENT_VAR_REGEX")
 });
 
+/// Fork regex to match fork installations in the format `owner/repo@ref`.
+/// Where `owner` is the GitHub username, `repo` is the repository name, and `ref` is a branch or commit hash.
+///
+/// # Example
+///
+/// ```rust
+/// assert!(FORK_REGEX.is_match("username/neovim@feature-branch"));
+/// assert!(FORK_REGEX.is_match("username/neovim@abc1234"));
+/// ```
+pub static FORK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)@([^\s]+)$")
+        .expect("Failed to compile static FORK_REGEX")
+});
+
 /// # Unix platform-specific compile time constant for the filetype extension of the Neovim binary extension.
 ///
 /// For Windows, it returns "zip".
@@ -101,3 +115,87 @@ pub const FILETYPE_EXT: &str = "tar.gz";
 /// ```
 #[cfg(target_family = "windows")]
 pub const FILETYPE_EXT: &str = "zip";
+
+#[cfg(test)]
+mod fork_regex_tests {
+    use super::*;
+
+    #[test]
+    fn test_fork_regex_with_valid_formats() {
+        let valid_cases = [
+            "username/neovim@feature-branch",
+            "user-name/repo-name@branch-name",
+            "user_name/repo_name@branch_name",
+            "user123/repo456@branch789",
+            "username/neovim@abc1234",
+            "username/neovim@v1.0.0",
+            "username/neovim@refs/heads/main",
+            "octo-cat/my-nvim@feature/new-thing",
+        ];
+
+        for case in valid_cases {
+            assert!(
+                FORK_REGEX.is_match(case),
+                "Expected '{}' to match fork regex",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn test_fork_regex_with_invalid_formats() {
+        let invalid_cases = [
+            "username/neovim",            // Missing @ref
+            "username@neovim",            // Wrong separator
+            "neovim@branch",              // Missing repo
+            "@branch",                    // Missing owner and repo
+            "username/",                  // Missing repo and ref
+            "/neovim@branch",             // Missing owner
+            "username/@branch",           // Missing repo
+            "user name/neovim@branch",    // Space in owner
+            "username/neo vim@branch",    // Space in repo
+            "username/neovim@branch asd", // Trailing @
+            "",                           // Empty string
+            "justtext",                   // No format
+        ];
+
+        for case in invalid_cases {
+            assert!(
+                !FORK_REGEX.is_match(case),
+                "Expected '{}' to not match fork regex",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn test_fork_regex_captures_components() {
+        let fork_string = "myuser/myrepo@mybranch";
+        let captures = FORK_REGEX.captures(fork_string).unwrap();
+
+        assert_eq!(captures.get(1).unwrap().as_str(), "myuser");
+        assert_eq!(captures.get(2).unwrap().as_str(), "myrepo");
+        assert_eq!(captures.get(3).unwrap().as_str(), "mybranch");
+    }
+
+    #[test]
+    fn test_fork_regex_with_complex_ref() {
+        let fork_string = "user/repo@refs/heads/feature/new-branch";
+        assert!(FORK_REGEX.is_match(fork_string));
+
+        let captures = FORK_REGEX.captures(fork_string).unwrap();
+        assert_eq!(
+            captures.get(3).unwrap().as_str(),
+            "refs/heads/feature/new-branch"
+        );
+    }
+
+    #[test]
+    fn test_fork_regex_with_commit_hash_ref() {
+        let fork_string = "user/repo@abc123def456";
+        assert!(FORK_REGEX.is_match(fork_string));
+
+        let captures = FORK_REGEX.captures(fork_string).unwrap();
+        assert_eq!(captures.get(3).unwrap().as_str(), "abc123def456");
+    }
+}

--- a/src/github_requests.rs
+++ b/src/github_requests.rs
@@ -291,6 +291,50 @@ pub async fn get_commits_for_nightly(
     deserialize_response(&response)
 }
 
+/// Fetches the commit SHA for a specific ref in a fork repository.
+///
+/// This function sends a GET request to the GitHub API to fetch commit information
+/// for a specific ref (branch, tag, or commit) in a fork repository.
+///
+/// # Parameters
+///
+/// * `client: &Client` - The HTTP client used to send the request.
+/// * `owner: &str` - The owner of the fork repository.
+/// * `repo: &str` - The name of the fork repository.
+/// * `ref_name: &str` - The ref (branch, tag, or commit SHA) to fetch.
+///
+/// # Returns
+///
+/// * `Result<String>` - The full commit SHA, or an error if the request failed.
+///
+/// # Errors
+///
+/// This function will return an error if the request to the GitHub API fails or if
+/// the response cannot be deserialized.
+///
+/// # Example
+///
+/// ```rust
+/// let client = Client::new();
+/// let sha = get_fork_commit(&client, "user", "neovim", "main").await?;
+/// println!("Latest commit SHA: {}", sha);
+/// ```
+pub async fn get_fork_commit(
+    client: &Client,
+    owner: &str,
+    repo: &str,
+    ref_name: &str,
+) -> Result<String> {
+    let response = make_github_request(
+        client,
+        format!("https://api.github.com/repos/{owner}/{repo}/commits/{ref_name}"),
+    )
+    .await?;
+
+    let commit: RepoCommit = deserialize_response(&response)?;
+    Ok(commit.sha)
+}
+
 /// Deserializes a JSON response from the GitHub API.
 ///
 /// This function takes a JSON response as a string and attempts to deserialize it into a specified type `T`. If the response contains a "message" field, it is treated as an error response, and the function will return an error with the message from the response. If the error is related to rate limiting, a specific error message is returned.

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -128,7 +128,9 @@ pub async fn start(
                 download_version(client, version, root, &config.config, false).await
             }
         }
-        VersionType::Hash => handle_building_from_source(version, &config.config).await,
+        VersionType::Hash | VersionType::Fork => {
+            handle_building_from_source(version, &config.config).await
+        }
         VersionType::NightlyRollback => Ok(PostDownloadVersionType::None),
     }?;
 
@@ -411,7 +413,7 @@ async fn download_version(
                 ))
             }
         }
-        VersionType::Hash => handle_building_from_source(version, config).await,
+        VersionType::Hash | VersionType::Fork => handle_building_from_source(version, config).await,
         VersionType::NightlyRollback => Ok(PostDownloadVersionType::None),
     }
 }
@@ -583,20 +585,38 @@ async fn handle_building_from_source(version: &ParsedVersion, config: &Config) -
 
     {
 
+    // Determine repository URL based on whether it's a fork or the main neovim repo
+    let repo_url = if version.version_type == VersionType::Fork {
+        format!(
+            "https://github.com/{}/{}.git",
+            version.fork_owner.as_ref().unwrap(),
+            version.fork_repo.as_ref().unwrap()
+        )
+    } else {
+        "https://github.com/neovim/neovim.git".to_string()
+    };
+
+    // Determine the ref to fetch
+    let fetch_ref = if version.version_type == VersionType::Fork {
+        version.fork_ref.as_ref().unwrap()
+    } else {
+        &version.non_parsed_string
+    };
+
     // check if repo has a remote
     let remote = Command::new("git").arg("remote").arg("get-url").arg("origin").stdout(Stdio::null())
         .spawn()?.wait().await?;
     if remote.success() {
-        // set neovim's remote
-        Command::new("git").arg("remote").arg("set-url").arg("origin").arg("https://github.com/neovim/neovim.git")
+        // set repository remote
+        Command::new("git").arg("remote").arg("set-url").arg("origin").arg(&repo_url)
             .spawn()?.wait().await?;
     } else {
-        // add neovim's remote otherwise
-        Command::new("git").arg("remote").arg("add").arg("origin").arg("https://github.com/neovim/neovim.git")
+        // add repository remote otherwise
+        Command::new("git").arg("remote").arg("add").arg("origin").arg(&repo_url)
             .spawn()?.wait().await?;
     }
     // fetch version from origin
-    let fetch_successful = Command::new("git").arg("fetch").arg("--depth").arg("1").arg("origin").arg(&version.non_parsed_string)
+    let fetch_successful = Command::new("git").arg("fetch").arg("--depth").arg("1").arg("origin").arg(fetch_ref)
         .spawn()?.wait().await?.success();
 
     if !fetch_successful {
@@ -617,7 +637,7 @@ async fn handle_building_from_source(version: &ParsedVersion, config: &Config) -
     fs::create_dir("build").await?;
 
     let downloads_location = directories::get_downloads_directory(config).await?;
-    let folder_name = downloads_location.join(&version.tag_name[0..7]);
+    let folder_name = downloads_location.join( if version.version_type == VersionType::Fork { &version.tag_name } else { &version.tag_name[0..7] } );
 
     let build_type = match config.enable_release_build {
         Some(true) => "Release",

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -1,5 +1,7 @@
 use crate::config::{Config, ConfigFile};
-use crate::github_requests::{UpstreamVersion, get_commits_for_nightly, get_upstream_nightly};
+use crate::github_requests::{
+    UpstreamVersion, get_commits_for_nightly, get_fork_commit, get_upstream_nightly,
+};
 use crate::helpers::checksum::sha256cmp;
 use crate::helpers::processes::handle_subprocess;
 use crate::helpers::version::nightly::produce_nightly_vec;
@@ -86,7 +88,12 @@ pub async fn start(
     let is_version_installed =
         helpers::version::is_version_installed(&version.tag_name, &config.config).await?;
 
-    if is_version_installed && version.version_type != VersionType::Nightly {
+    if is_version_installed
+        && !matches!(
+            version.version_type,
+            VersionType::Nightly | VersionType::Fork
+        )
+    {
         return Ok(InstallResult::VersionAlreadyInstalled);
     }
 
@@ -114,6 +121,30 @@ pub async fn start(
             }
             None => print_commits(client, &local_nightly, upstream_nightly).await?,
             _ => (),
+        }
+    }
+
+    if is_version_installed && version.version_type == VersionType::Fork {
+        info!("Checking for fork updates");
+
+        let fork_owner = version.fork_owner.as_ref().unwrap();
+        let fork_repo = version.fork_repo.as_ref().unwrap();
+        let fork_ref = version.fork_ref.as_ref().unwrap();
+
+        // Get remote commit hash
+        let remote_hash = get_fork_commit(client, fork_owner, fork_repo, fork_ref).await?;
+
+        // Read local commit hash from full-hash.txt
+        let local_hash_path = directories::get_downloads_directory(&config.config)
+            .await?
+            .join(&version.tag_name)
+            .join("full-hash.txt");
+
+        if let Ok(local_hash) = fs::read_to_string(&local_hash_path).await {
+            let local_hash = local_hash.trim();
+            if remote_hash == local_hash {
+                return Ok(InstallResult::ForkIsUpdated);
+            }
         }
     }
 
@@ -658,8 +689,9 @@ async fn handle_building_from_source(version: &ParsedVersion, config: &Config) -
         }
     }
 
+    let full_hash = Command::new("git").arg("rev-parse").arg("HEAD").output().await?.stdout;
     let mut file = File::create(folder_name.join("full-hash.txt")).await?;
-    file.write_all(version.non_parsed_string.as_bytes()).await?;
+    file.write_all(&full_hash).await?;
 
     Ok(PostDownloadVersionType::Hash)
 }

--- a/src/handlers/list_handler.rs
+++ b/src/handlers/list_handler.rs
@@ -5,8 +5,45 @@ use yansi::Paint;
 
 use crate::{
     config::Config,
-    helpers::{self, directories, version::nightly::produce_nightly_vec},
+    helpers::{self, directories},
 };
+
+/// Recursively finds all version directories in the downloads directory.
+///
+/// This function searches through the directory tree starting from `current_dir`,
+/// looking for directories that contain a valid Neovim installation (indicated by
+/// the presence of a `bin` subdirectory).
+///
+/// # Arguments
+///
+/// * `current_dir` - The current directory being searched
+///
+/// # Returns
+///
+/// * `Result<Vec<PathBuf>>` - A vector of paths to version directories with their
+///   relative paths from the base directory
+fn find_version_dirs(current_dir: &PathBuf) -> Result<Vec<PathBuf>> {
+    let mut version_dirs = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(current_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+
+            if !path.is_dir() {
+                continue;
+            }
+
+            let nvim_exe = path.join("bin").join("nvim");
+            if nvim_exe.exists() && nvim_exe.is_file() {
+                version_dirs.push(path);
+            } else if let Ok(mut subdirs) = find_version_dirs(&path) {
+                version_dirs.append(&mut subdirs);
+            }
+        }
+    }
+
+    Ok(version_dirs)
+}
 
 /// Starts the list handler.
 ///
@@ -30,17 +67,34 @@ use crate::{
 pub async fn start(config: Config) -> Result<()> {
     let downloads_dir = directories::get_downloads_directory(&config).await?;
 
-    let paths: Vec<PathBuf> = fs::read_dir(downloads_dir)?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .collect();
+    // Recursively find all version directories
+    let paths = find_version_dirs(&downloads_dir)?;
 
     if paths.is_empty() {
         info!("There are no versions installed");
         return Ok(());
     }
 
-    let version_max_len = if has_rollbacks(&config).await? { 16 } else { 7 };
+    let relative_paths = paths
+        .iter()
+        .map(|path| path.strip_prefix(&downloads_dir).unwrap())
+        .filter(|path| !path.starts_with("neovim-git/build"))
+        .map(|path| path.to_str().unwrap())
+        .collect::<Vec<&str>>();
+
+    // Calculate the maximum version name length dynamically
+    let version_max_len = relative_paths
+        .iter()
+        .filter_map(|path| {
+            if !is_version(path) {
+                return None;
+            }
+            Some(path.len())
+        })
+        .max()
+        .unwrap_or(7)
+        .max(7); // Ensure at least 7 for the "Version" header
+
     let status_max_len = 9;
     let padding = 2;
 
@@ -62,17 +116,7 @@ pub async fn start(config: Config) -> Result<()> {
         "─".repeat(status_max_len + (padding * 2))
     );
 
-    for path in paths {
-        if !path.is_dir() {
-            continue;
-        }
-
-        let path_name = path.file_name().unwrap().to_str().unwrap();
-
-        if !is_version(path_name) {
-            continue;
-        }
-
+    for path_name in relative_paths {
         let version_pr = (version_max_len - path_name.len()) + padding;
         let status_pr = padding + status_max_len;
 
@@ -106,34 +150,10 @@ pub async fn start(config: Config) -> Result<()> {
     Ok(())
 }
 
-/// Checks if there are any rollbacks available.
-///
-/// This function produces a vector of nightly versions and checks if it is empty.
-///
-/// # Arguments
-///
-/// * `config` - A reference to the configuration object.
-///
-/// # Returns
-///
-/// * `Result<bool>` - Returns a `Result` that contains `true` if there are rollbacks available, or `false` otherwise. Returns an error if there is a failure in producing the vector of nightly versions.
-///
-/// # Example
-///
-/// ```rust
-/// let config = Config::default();
-/// let has_rollbacks = has_rollbacks(&config).await?;
-/// assert_eq!(has_rollbacks, true);
-/// ```
-async fn has_rollbacks(config: &Config) -> Result<bool> {
-    let list = produce_nightly_vec(config).await?;
-
-    Ok(!list.is_empty())
-}
-
 /// Checks if a given string is a valid version.
 ///
-/// This function checks if the given string is "stable", contains "nightly", or matches the version or hash regex.
+/// This function checks if the given string is "stable", contains "nightly", matches the version or hash regex,
+/// or is a fork version (contains forward slashes).
 ///
 /// # Arguments
 ///
@@ -155,10 +175,9 @@ fn is_version(name: &str) -> bool {
         "stable" => true,
         nightly_name if nightly_name.contains("nightly") => true,
         name => {
-            if crate::VERSION_REGEX.is_match(name) {
-                return true;
-            }
-            crate::HASH_REGEX.is_match(name)
+            crate::FORK_REGEX.is_match(name)
+                || crate::VERSION_REGEX.is_match(name)
+                || crate::HASH_REGEX.is_match(name)
         }
     }
 }
@@ -175,6 +194,9 @@ mod list_handler_is_version_tests {
             ("nightly-2023-10-01", true),
             ("invalid-version", false),
             ("", false),
+            ("user/repo@branch", true),  // fork version
+            ("owner/fork@main", true),   // fork version
+            ("user/repo/branch", false), // invalid fork format (missing @)
         ];
 
         cases_expected

--- a/src/handlers/list_handler.rs
+++ b/src/handlers/list_handler.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::{fs, path::PathBuf};
 use tracing::info;
 use yansi::Paint;
 
@@ -7,43 +6,6 @@ use crate::{
     config::Config,
     helpers::{self, directories},
 };
-
-/// Recursively finds all version directories in the downloads directory.
-///
-/// This function searches through the directory tree starting from `current_dir`,
-/// looking for directories that contain a valid Neovim installation (indicated by
-/// the presence of a `bin` subdirectory).
-///
-/// # Arguments
-///
-/// * `current_dir` - The current directory being searched
-///
-/// # Returns
-///
-/// * `Result<Vec<PathBuf>>` - A vector of paths to version directories with their
-///   relative paths from the base directory
-fn find_version_dirs(current_dir: &PathBuf) -> Result<Vec<PathBuf>> {
-    let mut version_dirs = Vec::new();
-
-    if let Ok(entries) = fs::read_dir(current_dir) {
-        for entry in entries.filter_map(Result::ok) {
-            let path = entry.path();
-
-            if !path.is_dir() {
-                continue;
-            }
-
-            let nvim_exe = path.join("bin").join("nvim");
-            if nvim_exe.exists() && nvim_exe.is_file() {
-                version_dirs.push(path);
-            } else if let Ok(mut subdirs) = find_version_dirs(&path) {
-                version_dirs.append(&mut subdirs);
-            }
-        }
-    }
-
-    Ok(version_dirs)
-}
 
 /// Starts the list handler.
 ///
@@ -67,8 +29,8 @@ fn find_version_dirs(current_dir: &PathBuf) -> Result<Vec<PathBuf>> {
 pub async fn start(config: Config) -> Result<()> {
     let downloads_dir = directories::get_downloads_directory(&config).await?;
 
-    // Recursively find all version directories
-    let paths = find_version_dirs(&downloads_dir)?;
+    // Recursively find all version directories (build directories are filtered out)
+    let paths = directories::find_version_dirs(&downloads_dir, &downloads_dir)?;
 
     if paths.is_empty() {
         info!("There are no versions installed");
@@ -78,7 +40,6 @@ pub async fn start(config: Config) -> Result<()> {
     let relative_paths = paths
         .iter()
         .map(|path| path.strip_prefix(&downloads_dir).unwrap())
-        .filter(|path| !path.starts_with("neovim-git/build"))
         .map(|path| path.to_str().unwrap())
         .collect::<Vec<&str>>();
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -24,6 +24,7 @@ pub enum InstallResult {
     VersionAlreadyInstalled,
     NightlyIsUpdated,
     GivenNightlyRollback,
+    ForkIsUpdated,
 }
 
 /// Represents the type of a version after it has been downloaded.

--- a/src/handlers/rollback_handler.rs
+++ b/src/handlers/rollback_handler.rs
@@ -67,6 +67,9 @@ pub async fn start(config: Config) -> Result<()> {
                 version_type: helpers::version::types::VersionType::Normal,
                 non_parsed_string: String::default(),
                 semver: None,
+                fork_owner: None,
+                fork_repo: None,
+                fork_ref: None,
             },
         )
         .await?;

--- a/src/handlers/uninstall_handler.rs
+++ b/src/handlers/uninstall_handler.rs
@@ -8,8 +8,9 @@ use dialoguer::{
     console::{Term, style},
     theme::ColorfulTheme,
 };
+use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
-use tokio::fs;
+use tokio::fs as async_fs;
 use tracing::{info, warn};
 
 /// Starts the uninstall process.
@@ -44,7 +45,7 @@ pub async fn start(version: Option<&str>, config: Config) -> Result<()> {
     let client = Client::new();
 
     let Some(version) = version else {
-        return uninstall_selections(&client, &config).await;
+        return uninstall_selections(&config).await;
     };
 
     let version = helpers::version::parse_version_type(&client, version).await?;
@@ -60,7 +61,11 @@ pub async fn start(version: Option<&str>, config: Config) -> Result<()> {
 
     let path = downloads_dir.join(&version.tag_name);
 
-    fs::remove_dir_all(path).await?;
+    async_fs::remove_dir_all(&path).await?;
+
+    // Clean up empty parent directories
+    directories::remove_empty_parents(&path, &downloads_dir)?;
+
     info!(
         "Successfully uninstalled version: {}",
         version.non_parsed_string
@@ -70,11 +75,12 @@ pub async fn start(version: Option<&str>, config: Config) -> Result<()> {
 
 /// Uninstalls selected versions.
 ///
-/// This function reads the versions from the downloads directory, presents a list of installed versions to the user, allows them to select versions to uninstall, and then uninstalls the selected versions.
+/// This function recursively searches the downloads directory for all installed versions,
+/// presents a list of available versions to the user, allows them to select versions to
+/// uninstall, and then uninstalls the selected versions.
 ///
 /// # Arguments
 ///
-/// * `client` - The HTTP client to be used for network requests.
 /// * `config` - The configuration for the uninstall process.
 ///
 /// # Returns
@@ -86,36 +92,42 @@ pub async fn start(version: Option<&str>, config: Config) -> Result<()> {
 /// This function will return an error if:
 ///
 /// * The downloads directory cannot be read.
-/// * The version cannot be parsed from the file name.
-/// * The version is currently in use.
+/// * The version directories cannot be found recursively.
 /// * The user aborts the uninstall process.
 ///
 /// # Example
 ///
 /// ```rust
-/// let client = Client::new();
 /// let config = Config::default();
-/// uninstall_selections(&client, &config).await.unwrap();
+/// uninstall_selections(&config).await.unwrap();
 /// ```
-async fn uninstall_selections(client: &Client, config: &Config) -> Result<()> {
+async fn uninstall_selections(config: &Config) -> Result<()> {
     let downloads_dir = directories::get_downloads_directory(config).await?;
 
-    let mut paths = fs::read_dir(downloads_dir.clone()).await?;
-    let mut installed_versions: Vec<String> = Vec::new();
+    // Recursively find all version directories (build directories are filtered out)
+    let paths = directories::find_version_dirs(&downloads_dir, &downloads_dir)?;
 
-    while let Some(path) = paths.next_entry().await? {
-        let name = path.file_name().to_str().unwrap().to_owned();
-
-        let Ok(version) = helpers::version::parse_version_type(client, &name).await else {
-            warn!("Could not parse version from file name: {}", name);
-            continue;
-        };
-
-        if helpers::version::is_version_used(&version.non_parsed_string, config).await {
-            continue;
-        }
-        installed_versions.push(version.non_parsed_string);
+    if paths.is_empty() {
+        info!("There are no versions installed");
+        return Ok(());
     }
+
+    // Filter out currently used versions and collect version names with their paths
+    let installed_versions = stream::iter(paths)
+        .filter_map(|path| {
+            let downloads_dir = downloads_dir.clone();
+            async move {
+                let version_name = path.strip_prefix(&downloads_dir).unwrap().to_str().unwrap();
+
+                if !helpers::version::is_version_used(version_name, config).await {
+                    Some((version_name.to_owned(), path))
+                } else {
+                    None
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .await;
 
     if installed_versions.is_empty() {
         info!("You only have one neovim instance installed");
@@ -128,9 +140,14 @@ async fn uninstall_selections(client: &Client, config: &Config) -> Result<()> {
         ..ColorfulTheme::default()
     };
 
+    let version_names: Vec<&str> = installed_versions
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect();
+
     let selections = MultiSelect::with_theme(&theme)
         .with_prompt("Toogle with space the versions you wish to uninstall:")
-        .items(&installed_versions)
+        .items(&version_names)
         .interact_on_opt(&Term::stderr())?;
 
     match &selections {
@@ -145,12 +162,13 @@ async fn uninstall_selections(client: &Client, config: &Config) -> Result<()> {
             }
 
             for &i in ids {
-                let path = downloads_dir.join(&installed_versions[i]);
-                fs::remove_dir_all(path).await?;
-                info!(
-                    "Successfully uninstalled version: {}",
-                    &installed_versions[i]
-                );
+                let (version_name, path) = &installed_versions[i];
+                async_fs::remove_dir_all(path).await?;
+
+                // Clean up empty parent directories
+                directories::remove_empty_parents(path, &downloads_dir)?;
+
+                info!("Successfully uninstalled version: {}", version_name);
             }
         }
         None | Some(_) => info!("Uninstall aborted..."),

--- a/src/handlers/update_handler.rs
+++ b/src/handlers/update_handler.rs
@@ -59,6 +59,7 @@ pub async fn start(data: Update, client: &Client, config: ConfigFile) -> Result<
                 InstallResult::InstallationSuccess(_) => did_update = true,
                 InstallResult::VersionAlreadyInstalled
                 | InstallResult::NightlyIsUpdated
+                | InstallResult::ForkIsUpdated
                 | InstallResult::GivenNightlyRollback => (),
             }
         }
@@ -68,6 +69,7 @@ pub async fn start(data: Update, client: &Client, config: ConfigFile) -> Result<
             match install_handler::start(&nightly, client, &config).await? {
                 InstallResult::InstallationSuccess(_) => did_update = true,
                 InstallResult::NightlyIsUpdated
+                | InstallResult::ForkIsUpdated
                 | InstallResult::VersionAlreadyInstalled
                 | InstallResult::GivenNightlyRollback => (),
             }
@@ -89,6 +91,7 @@ pub async fn start(data: Update, client: &Client, config: ConfigFile) -> Result<
     match install_handler::start(&version, client, &config).await? {
         InstallResult::NightlyIsUpdated => info!("Nightly is already updated!"),
         InstallResult::VersionAlreadyInstalled => info!("Stable is already updated!"),
+        InstallResult::ForkIsUpdated => info!("{} is already updated!", version.tag_name),
         InstallResult::InstallationSuccess(_) | InstallResult::GivenNightlyRollback => (),
     }
     Ok(())

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -55,7 +55,12 @@ pub async fn start(
         helpers::version::is_version_used(&version.tag_name, &config.config).await;
 
     copy_nvim_proxy(&config).await?;
-    if is_version_used && version.tag_name != "nightly" {
+    if is_version_used
+        && !matches!(
+            version.version_type,
+            VersionType::Nightly | VersionType::Fork
+        )
+    {
         info!("{} is already installed and used!", version.tag_name);
         return Ok(());
     }
@@ -66,6 +71,11 @@ pub async fn start(
                 if let InstallResult::NightlyIsUpdated = success {
                     if is_version_used {
                         info!("Nightly is already updated and used!");
+                        return Ok(());
+                    }
+                } else if let InstallResult::ForkIsUpdated = success {
+                    if is_version_used {
+                        info!("{} is already updated and used!", version.tag_name);
                         return Ok(());
                     }
                 }

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -124,7 +124,9 @@ pub async fn start(
 pub async fn switch(config: &Config, version: &ParsedVersion) -> Result<()> {
     std::env::set_current_dir(helpers::directories::get_downloads_directory(config).await?)?;
 
-    let file_version: String = if version.version_type == VersionType::Hash {
+    let file_version: String = if version.version_type == VersionType::Fork {
+        version.non_parsed_string.clone()
+    } else if version.version_type == VersionType::Hash {
         if version.non_parsed_string.len() <= 7 {
             let mut current_dir = env::current_dir()?;
             current_dir.push(&version.non_parsed_string);

--- a/src/helpers/directories.rs
+++ b/src/helpers/directories.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 
@@ -200,5 +200,282 @@ pub async fn get_installation_directory(config: &Config) -> Result<PathBuf> {
         installation_location.push("nvim-bin");
 
         Ok(installation_location)
+    }
+}
+
+/// Recursively finds all version directories in the downloads directory.
+///
+/// This function searches through the directory tree starting from `current_dir`,
+/// looking for directories that contain a valid Neovim installation (indicated by
+/// the presence of a `bin` subdirectory). Build directories (neovim-git/build) are
+/// automatically filtered out.
+///
+/// # Arguments
+///
+/// * `current_dir` - The current directory being searched
+/// * `base_dir` - The base downloads directory used to compute relative paths for filtering
+///
+/// # Returns
+///
+/// * `Result<Vec<PathBuf>>` - A vector of paths to version directories, excluding build directories
+///
+/// # Example
+///
+/// ```rust
+/// let downloads_dir = PathBuf::from("/path/to/downloads");
+/// let version_dirs = find_version_dirs(&downloads_dir, &downloads_dir)?;
+/// ```
+pub fn find_version_dirs(current_dir: &PathBuf, base_dir: &PathBuf) -> Result<Vec<PathBuf>> {
+    let mut version_dirs = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(current_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+
+            if !path.is_dir() {
+                continue;
+            }
+
+            let nvim_exe = path.join("bin").join("nvim");
+            if nvim_exe.exists() && nvim_exe.is_file() {
+                // Filter out build directories
+                if let Ok(relative_path) = path.strip_prefix(base_dir) {
+                    if !relative_path.starts_with("neovim-git/build") {
+                        version_dirs.push(path);
+                    }
+                }
+            } else if let Ok(mut subdirs) = find_version_dirs(&path, base_dir) {
+                version_dirs.append(&mut subdirs);
+            }
+        }
+    }
+
+    Ok(version_dirs)
+}
+
+/// Removes empty parent directories up to (but not including) the base directory.
+///
+/// This function is useful for cleaning up nested directory structures after
+/// removing a version. For example, after removing `user/repo@branch`, it will
+/// remove empty `user/repo` and `user` directories if they're empty.
+///
+/// # Arguments
+///
+/// * `path` - The path that was just removed
+/// * `base_dir` - The base directory to stop at (e.g., downloads directory)
+///
+/// # Returns
+///
+/// * `Result<()>` - Returns `Ok(())` if successful or if no cleanup was needed
+///
+/// # Example
+///
+/// ```rust
+/// let removed_path = PathBuf::from("/downloads/user/repo@branch");
+/// let base = PathBuf::from("/downloads");
+/// remove_empty_parents(&removed_path, &base)?;
+/// // This will remove /downloads/user/repo and /downloads/user if they're empty
+/// ```
+pub fn remove_empty_parents(path: &Path, base_dir: &PathBuf) -> Result<()> {
+    let mut current = path.parent();
+
+    while let Some(parent) = current {
+        // Stop if we've reached the base directory
+        if parent == base_dir {
+            break;
+        }
+
+        // Check if directory is empty
+        if let Ok(mut entries) = fs::read_dir(parent) {
+            if entries.next().is_none() {
+                // Directory is empty, remove it
+                fs::remove_dir(parent)?;
+                current = parent.parent();
+            } else {
+                // Directory is not empty, stop cleanup
+                break;
+            }
+        } else {
+            // Can't read directory, stop cleanup
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+
+    fn create_test_nvim_install(base: &PathBuf, relative_path: &str) -> PathBuf {
+        let install_path = base.join(relative_path);
+        let bin_path = install_path.join("bin");
+
+        fs::create_dir_all(&bin_path).unwrap();
+        File::create(bin_path.join("nvim")).unwrap();
+
+        install_path
+    }
+
+    #[test]
+    fn test_find_version_dirs_single_version() {
+        let temp_dir = std::env::temp_dir().join("bob_test_single");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Create a single version
+        create_test_nvim_install(&temp_dir, "v0.9.0");
+
+        let results = find_version_dirs(&temp_dir, &temp_dir).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].ends_with("v0.9.0"));
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_find_version_dirs_multiple_versions() {
+        let temp_dir = std::env::temp_dir().join("bob_test_multiple");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Create multiple versions
+        create_test_nvim_install(&temp_dir, "v0.9.0");
+        create_test_nvim_install(&temp_dir, "v0.9.1");
+        create_test_nvim_install(&temp_dir, "stable");
+
+        let results = find_version_dirs(&temp_dir, &temp_dir).unwrap();
+
+        assert_eq!(results.len(), 3);
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_find_version_dirs_nested_fork_versions() {
+        let temp_dir = std::env::temp_dir().join("bob_test_forks");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Create nested fork versions
+        create_test_nvim_install(&temp_dir, "user/repo@main");
+        create_test_nvim_install(&temp_dir, "user/repo@dev");
+        create_test_nvim_install(&temp_dir, "other/fork@branch");
+
+        let results = find_version_dirs(&temp_dir, &temp_dir).unwrap();
+
+        assert_eq!(results.len(), 3);
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_find_version_dirs_filters_build_directories() {
+        let temp_dir = std::env::temp_dir().join("bob_test_build_filter");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Create regular version
+        create_test_nvim_install(&temp_dir, "v0.9.0");
+
+        // Create build directory (should be filtered)
+        create_test_nvim_install(&temp_dir, "neovim-git/build");
+
+        let results = find_version_dirs(&temp_dir, &temp_dir).unwrap();
+
+        // Should only find v0.9.0, not the build directory
+        assert_eq!(results.len(), 1);
+        assert!(results[0].ends_with("v0.9.0"));
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_find_version_dirs_ignores_non_nvim_directories() {
+        let temp_dir = std::env::temp_dir().join("bob_test_non_nvim");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Create a valid nvim install
+        create_test_nvim_install(&temp_dir, "v0.9.0");
+
+        // Create directories without nvim binary
+        fs::create_dir_all(temp_dir.join("not_a_version")).unwrap();
+        fs::create_dir_all(temp_dir.join("another/nested/dir")).unwrap();
+
+        let results = find_version_dirs(&temp_dir, &temp_dir).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].ends_with("v0.9.0"));
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_remove_empty_parents_single_level() {
+        let temp_dir = std::env::temp_dir().join("bob_test_cleanup_single");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let nested = temp_dir.join("user");
+        fs::create_dir_all(&nested).unwrap();
+
+        // Remove the nested directory and cleanup
+        fs::remove_dir(&nested).unwrap();
+        remove_empty_parents(&nested, &temp_dir).unwrap();
+
+        // Parent should still exist (it's the base dir)
+        assert!(temp_dir.exists());
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_remove_empty_parents_multiple_levels() {
+        let temp_dir = std::env::temp_dir().join("bob_test_cleanup_multi");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let nested = temp_dir.join("user").join("repo@branch");
+        fs::create_dir_all(&nested).unwrap();
+
+        // Remove the deepest directory and cleanup
+        fs::remove_dir(&nested).unwrap();
+        remove_empty_parents(&nested, &temp_dir).unwrap();
+
+        // All intermediate directories should be removed
+        assert!(!temp_dir.join("user").join("repo@branch").exists());
+        assert!(!temp_dir.join("user").exists());
+        assert!(temp_dir.exists());
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_remove_empty_parents_stops_at_non_empty() {
+        let temp_dir = std::env::temp_dir().join("bob_test_cleanup_stop");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let user_dir = temp_dir.join("user");
+        let repo1 = user_dir.join("repo1@main");
+        let repo2 = user_dir.join("repo2@main");
+
+        fs::create_dir_all(&repo1).unwrap();
+        fs::create_dir_all(&repo2).unwrap();
+
+        // Remove repo1 and cleanup
+        fs::remove_dir(&repo1).unwrap();
+        remove_empty_parents(&repo1, &temp_dir).unwrap();
+
+        // user_dir should still exist because repo2 is there
+        assert!(user_dir.exists());
+        assert!(repo2.exists());
+        assert!(!repo1.exists());
+
+        fs::remove_dir_all(&temp_dir).unwrap();
     }
 }

--- a/src/helpers/version/mod.rs
+++ b/src/helpers/version/mod.rs
@@ -225,16 +225,8 @@ pub async fn get_version_sync_file_location(config: &Config) -> Result<Option<Pa
 /// ```
 pub async fn is_version_installed(version: &str, config: &Config) -> Result<bool> {
     let downloads_dir = directories::get_downloads_directory(config).await?;
-    let mut dir = tokio::fs::read_dir(&downloads_dir).await?;
-
-    while let Some(directory) = dir.next_entry().await? {
-        let name = directory.file_name().to_str().unwrap().to_owned();
-        if !version.eq(&name) {
-            continue;
-        }
-        return Ok(true);
-    }
-    Ok(false)
+    let version_dir = downloads_dir.join(version);
+    Ok(version_dir.join("bin").join("nvim").is_file())
 }
 
 /// Retrieves the current version of Neovim being used.

--- a/src/helpers/version/mod.rs
+++ b/src/helpers/version/mod.rs
@@ -53,6 +53,9 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
             version_type: VersionType::Nightly,
             non_parsed_string: version.to_string(),
             semver: None,
+            fork_owner: None,
+            fork_repo: None,
+            fork_ref: None,
         }),
         "stable" | "latest" => {
             info!("Fetching latest version");
@@ -63,6 +66,9 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
                 version_type: VersionType::Latest,
                 non_parsed_string: version.to_string(),
                 semver: Some(Version::parse(&cloned_version.replace('v', ""))?),
+                fork_owner: None,
+                fork_repo: None,
+                fork_ref: None,
             })
         }
         "head" | "git" | "HEAD" => {
@@ -73,10 +79,28 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
                 version_type: VersionType::Hash,
                 non_parsed_string: latest_commit,
                 semver: None,
+                fork_owner: None,
+                fork_repo: None,
+                fork_ref: None,
             })
         }
         _ => {
-            if crate::VERSION_REGEX.is_match(version) {
+            if crate::FORK_REGEX.is_match(version) {
+                let captures = crate::FORK_REGEX.captures(version).unwrap();
+                let owner = captures.get(1).unwrap().as_str().to_string();
+                let repo = captures.get(2).unwrap().as_str().to_string();
+                let fork_ref = captures.get(3).unwrap().as_str().to_string();
+
+                return Ok(ParsedVersion {
+                    tag_name: version.to_string(),
+                    version_type: VersionType::Fork,
+                    non_parsed_string: version.to_string(),
+                    semver: None,
+                    fork_owner: Some(owner),
+                    fork_repo: Some(repo),
+                    fork_ref: Some(fork_ref),
+                });
+            } else if crate::VERSION_REGEX.is_match(version) {
                 let mut returned_version = version.to_string();
                 if !version.contains('v') {
                     returned_version.insert(0, 'v');
@@ -90,6 +114,9 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
                         Version::parse(&cloned_version.replace('v', ""))
                             .context("Unable to parse version string in parse_version_type")?,
                     ),
+                    fork_owner: None,
+                    fork_repo: None,
+                    fork_ref: None,
                 });
             } else if crate::HASH_REGEX.is_match(version) {
                 return Ok(ParsedVersion {
@@ -97,6 +124,9 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
                     version_type: VersionType::Hash,
                     non_parsed_string: version.to_string(),
                     semver: None,
+                    fork_owner: None,
+                    fork_repo: None,
+                    fork_ref: None,
                 });
             }
 
@@ -106,15 +136,19 @@ pub async fn parse_version_type(client: &Client, version: &str) -> Result<Parsed
                     version_type: VersionType::NightlyRollback,
                     non_parsed_string: version.to_string(),
                     semver: None,
+                    fork_owner: None,
+                    fork_repo: None,
+                    fork_ref: None,
                 });
             }
 
             Err(anyhow!(
                 "Please provide a proper version string. Valid options are:
 
-                    • stable|latest|nightly - Latest stable, most recent, or nightly build
-                    • [v]x.x.x              - Specific version (e.g., 0.6.0 or v0.6.0)
-                    • <commit-hash>         - Specific commit hash"
+                    • stable|latest|nightly     - Latest stable, most recent, or nightly build
+                    • [v]x.x.x                  - Specific version (e.g., 0.6.0 or v0.6.0)
+                    • <commit-hash>             - Specific commit hash
+                    • owner/repo@ref            - Install from fork at branch or hash"
             ))
         }
     }
@@ -369,5 +403,117 @@ mod version_is_hash_tests {
     fn test_is_hash_with_long_hash() {
         let version = "abc123abc123abc123abc123abc123abc123abc123";
         assert!(!is_hash(version));
+    }
+}
+
+#[cfg(test)]
+mod fork_version_parsing_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_fork_version_with_branch() {
+        let client = Client::new();
+        let version = "myuser/neovim@feature-branch";
+
+        let result = parse_version_type(&client, version).await;
+        assert!(result.is_ok());
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.version_type, VersionType::Fork);
+        assert_eq!(parsed.fork_owner, Some("myuser".to_string()));
+        assert_eq!(parsed.fork_repo, Some("neovim".to_string()));
+        assert_eq!(parsed.fork_ref, Some("feature-branch".to_string()));
+        assert_eq!(parsed.tag_name, version);
+        assert_eq!(parsed.non_parsed_string, version);
+        assert!(parsed.semver.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_parse_fork_version_with_commit_hash() {
+        let client = Client::new();
+        let version = "user123/repo456@abc1234def5678";
+
+        let result = parse_version_type(&client, version).await;
+        assert!(result.is_ok());
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.version_type, VersionType::Fork);
+        assert_eq!(parsed.fork_owner, Some("user123".to_string()));
+        assert_eq!(parsed.fork_repo, Some("repo456".to_string()));
+        assert_eq!(parsed.fork_ref, Some("abc1234def5678".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_parse_fork_version_with_underscores_and_hyphens() {
+        let client = Client::new();
+        let version = "user-name_123/repo_name-456@my-branch_v2";
+
+        let result = parse_version_type(&client, version).await;
+        assert!(result.is_ok());
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.version_type, VersionType::Fork);
+        assert_eq!(parsed.fork_owner, Some("user-name_123".to_string()));
+        assert_eq!(parsed.fork_repo, Some("repo_name-456".to_string()));
+        assert_eq!(parsed.fork_ref, Some("my-branch_v2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_parse_fork_version_with_complex_ref() {
+        let client = Client::new();
+        let version = "owner/repo@refs/heads/feature/new-api";
+
+        let result = parse_version_type(&client, version).await;
+        assert!(result.is_ok());
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.version_type, VersionType::Fork);
+        assert_eq!(
+            parsed.fork_ref,
+            Some("refs/heads/feature/new-api".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_non_fork_versions_still_work() {
+        let client = Client::new();
+
+        // Test nightly
+        let nightly = parse_version_type(&client, "nightly").await.unwrap();
+        assert_eq!(nightly.version_type, VersionType::Nightly);
+        assert!(nightly.fork_owner.is_none());
+        assert!(nightly.fork_repo.is_none());
+        assert!(nightly.fork_ref.is_none());
+
+        // Test version string
+        let version = parse_version_type(&client, "0.9.5").await.unwrap();
+        assert_eq!(version.version_type, VersionType::Normal);
+        assert!(version.fork_owner.is_none());
+        assert!(version.fork_repo.is_none());
+        assert!(version.fork_ref.is_none());
+
+        // Test hash
+        let hash = parse_version_type(&client, "abc123def456").await.unwrap();
+        assert_eq!(hash.version_type, VersionType::Hash);
+        assert!(hash.fork_owner.is_none());
+        assert!(hash.fork_repo.is_none());
+        assert!(hash.fork_ref.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_parse_invalid_fork_format() {
+        let client = Client::new();
+
+        // Missing @ref
+        let result = parse_version_type(&client, "username/neovim").await;
+        assert!(result.is_err());
+
+        // Wrong separator
+        let result = parse_version_type(&client, "username@neovim").await;
+        assert!(result.is_err());
+
+        // Missing repo
+        let result = parse_version_type(&client, "neovim@branch").await;
+        assert!(result.is_err());
     }
 }

--- a/src/helpers/version/types.rs
+++ b/src/helpers/version/types.rs
@@ -13,6 +13,9 @@ use std::path::PathBuf;
 /// * `version_type: VersionType` - The type of the parsed version.
 /// * `non_parsed_string: String` - The non-parsed string of the parsed version.
 /// * `semver: Option<Version>` - The semantic version of the parsed version, or `None` if the version is not a semantic version.
+/// * `fork_owner: Option<String>` - The owner of the fork repository, or `None` if not a fork.
+/// * `fork_repo: Option<String>` - The name of the fork repository, or `None` if not a fork.
+/// * `fork_ref: Option<String>` - The branch or commit reference for the fork, or `None` if not a fork.
 ///
 /// # Example
 ///
@@ -22,6 +25,9 @@ use std::path::PathBuf;
 ///     version_type: VersionType::Normal,
 ///     non_parsed_string: "version-1.0.0".to_string(),
 ///     semver: Some(Version::parse("1.0.0").unwrap()),
+///     fork_owner: None,
+///     fork_repo: None,
+///     fork_ref: None,
 /// };
 /// println!("The parsed version is {:?}", parsed_version);
 /// ```
@@ -30,6 +36,9 @@ pub struct ParsedVersion {
     pub version_type: VersionType,
     pub non_parsed_string: String,
     pub semver: Option<Version>,
+    pub fork_owner: Option<String>,
+    pub fork_repo: Option<String>,
+    pub fork_ref: Option<String>,
 }
 
 /// Represents the type of (a) software version.
@@ -43,6 +52,7 @@ pub struct ParsedVersion {
 /// * `Nightly` - Represents a nightly version.
 /// * `Hash` - Represents a version identified by a hash.
 /// * `NightlyRollback` - Represents a nightly version that has been rolled back.
+/// * `Fork` - Represents a version from a fork repository.
 ///
 /// # Example
 ///
@@ -54,6 +64,7 @@ pub struct ParsedVersion {
 ///     VersionType::Nightly => println!("This is a nightly version."),
 ///     VersionType::Hash => println!("This is a version identified by a hash."),
 ///     VersionType::NightlyRollback => println!("This is a nightly version that has been rolled back."),
+///     VersionType::Fork => println!("This is a version from a fork repository."),
 /// }
 /// ```
 #[derive(PartialEq, Eq, Debug)]
@@ -63,6 +74,7 @@ pub enum VersionType {
     Nightly,
     Hash,
     NightlyRollback,
+    Fork,
 }
 
 /// Represents a local nightly version of the software.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::{env, process::exit};
 use tracing::{Level, error, warn};
 
 pub(crate) use crate::consts::{
-    ENVIRONMENT_VAR_REGEX, FILETYPE_EXT, HASH_REGEX, NIGHTLY_REGEX, VERSION_REGEX,
+    ENVIRONMENT_VAR_REGEX, FILETYPE_EXT, FORK_REGEX, HASH_REGEX, NIGHTLY_REGEX, VERSION_REGEX,
 };
 
 #[tokio::main]


### PR DESCRIPTION
# Summary

- Closes #386

Adds support for installing a forked version of neovim.

## Description

A forked version is parsed as the following: `<owner>/<repo>@<ref>`, for example `PeterCardenas/neovim@support-mouse-shape`. In the download directory, the forward slashes are preserved and create directories. The clone happens in the `neovim-git` directory, similar to the `hash` version string method, but it will have the origin modified to have the owner and repo name.

The `bob ls` logic has also changed to recursively search through directories to find relative paths that match the forked version format.

Similar to `nightly`, forked versions are also checked for updates even when they're already installed, so that the version can be up to date with the latest commit on a branch.

There is a decent number of assumptions made across the codebase about the version string before this change, and this PR had to break some of those assumptions, including some logic specific to nightly (checking for updates) and hashes (building from source).

## Type of change

- [x] - New feature (non-breaking change which adds functionality)

## Checklist

<details>
  <summary>
    Checklist tick-boxes
  </summary>
<p>

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `cargo fmt`
- [x] - No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)

2. Best-Effort

- [x] - My changes generate no new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

3. Documentation

- [x] - Any documentation that relates to this PR has been updated
    or will be updated in a PR (Link here: )(if applicable)

4. Tests

- [x] - I have added tests that prove my fix is effective or that my feature works
- [x] - New and existing unit tests pass locally with my changes

5. Dependencies

- [x] - Any dependent changes have been merged and published in downstream modules

</p>
</details>
