### PR TITLE
fix: retry build with make distclean when failed

### DIFF
--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -611,11 +611,6 @@ async fn handle_building_from_source(version: &ParsedVersion, config: &Config) -
 
     }
 
-    if fs::metadata("build").await.is_ok() {
-        filesystem::remove_dir("build").await?;
-    }
-    fs::create_dir("build").await?;
-
     let downloads_location = directories::get_downloads_directory(config).await?;
     let folder_name = downloads_location.join(&version.tag_name[0..7]);
 

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -629,37 +629,28 @@ async fn handle_building_from_source(version: &ParsedVersion, config: &Config) -
         } else {
             let location_arg = format!("CMAKE_INSTALL_PREFIX={}", folder_name.to_string_lossy());
             
-            // Try to build, if either step fails, run distclean and try again once
-            let mut attempts = 0;
-            loop {
-                let make_result = handle_subprocess(Command::new("make").arg(&location_arg).arg(&build_arg)).await;
-                
-                if let Err(e) = make_result {
-                    if attempts == 0 {
-                        warn!("Make build failed, running make distclean and retrying");
-                        handle_subprocess(Command::new("make").arg("distclean")).await?;
-                        attempts += 1;
-                        continue;
-                    } else {
-                        return Err(e);
-                    }
-                }
-                
-                let install_result = handle_subprocess(Command::new("make").arg("install")).await;
-                
-                if let Err(e) = install_result {
-                    if attempts == 0 {
-                        warn!("Make install failed, running make distclean and retrying");
-                        handle_subprocess(Command::new("make").arg("distclean")).await?;
-                        attempts += 1;
-                        continue;
-                    } else {
-                        return Err(e);
-                    }
-                }
-                
-                // Both succeeded
-                break;
+            // First attempt
+            let build_result = handle_subprocess(Command::new("make").arg(&location_arg).arg(&build_arg)).await;
+            let mut install_result: Result<()> = Ok(());
+
+            if build_result.is_ok() {
+                install_result = handle_subprocess(Command::new("make").arg("install")).await;
+            }
+
+            if build_result.is_ok() && install_result.is_ok() {
+                // Success on the first attempt
+            } else {
+                // First attempt failed somewhere
+                let failed_phase = if build_result.is_err() { "build" } else { "install" };
+                warn!("Make {} failed, running make distclean and retrying", failed_phase);
+
+                // Propagation here
+                handle_subprocess(Command::new("make").arg("distclean")).await?;
+
+                // Second/final attempt. We always redo both phases after distclean
+                handle_subprocess(Command::new("make").arg(&location_arg).arg(&build_arg)).await?;
+                handle_subprocess(Command::new("make").arg("install")).await?;
+                // We know other phases succeeded, we're good
             }
         }
     }

--- a/src/handlers/install_handler.rs
+++ b/src/handlers/install_handler.rs
@@ -633,8 +633,39 @@ async fn handle_building_from_source(version: &ParsedVersion, config: &Config) -
 
         } else {
             let location_arg = format!("CMAKE_INSTALL_PREFIX={}", folder_name.to_string_lossy());
-            handle_subprocess(Command::new("make").arg(&location_arg).arg(&build_arg)).await?;
-            handle_subprocess(Command::new("make").arg("install")).await?;
+            
+            // Try to build, if either step fails, run distclean and try again once
+            let mut attempts = 0;
+            loop {
+                let make_result = handle_subprocess(Command::new("make").arg(&location_arg).arg(&build_arg)).await;
+                
+                if let Err(e) = make_result {
+                    if attempts == 0 {
+                        warn!("Make build failed, running make distclean and retrying");
+                        handle_subprocess(Command::new("make").arg("distclean")).await?;
+                        attempts += 1;
+                        continue;
+                    } else {
+                        return Err(e);
+                    }
+                }
+                
+                let install_result = handle_subprocess(Command::new("make").arg("install")).await;
+                
+                if let Err(e) = install_result {
+                    if attempts == 0 {
+                        warn!("Make install failed, running make distclean and retrying");
+                        handle_subprocess(Command::new("make").arg("distclean")).await?;
+                        attempts += 1;
+                        continue;
+                    } else {
+                        return Err(e);
+                    }
+                }
+                
+                // Both succeeded
+                break;
+            }
         }
     }
 

--- a/src/helpers/filesystem.rs
+++ b/src/helpers/filesystem.rs
@@ -1,66 +1,7 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use async_recursion::async_recursion;
-use indicatif::{ProgressBar, ProgressStyle};
 use std::path::Path;
 use tokio::fs;
-
-/// Asynchronously removes a directory and all its contents.
-///
-/// This function takes a string reference as an argument, which represents the directory to be removed.
-/// It first reads the directory and counts the number of entries. Then, it creates a progress bar with the total number of entries.
-/// It iterates over each entry in the directory. If the entry is a directory, it removes the directory and all its contents. If the entry is a file, it removes the file.
-/// After removing each entry, it updates the progress bar.
-/// Finally, it attempts to remove the directory itself. If this operation fails, it returns an error.
-///
-/// # Arguments
-///
-/// * `directory` - A string reference representing the directory to be removed.
-///
-/// # Returns
-///
-/// This function returns a `Result` that indicates whether the operation was successful.
-/// If the operation was successful, the function returns `Ok(())`.
-/// If the operation failed, the function returns `Err` with a description of the error.
-///
-/// # Example
-///
-/// ```rust
-/// let directory = "/path/to/directory";
-/// remove_dir(directory).await;
-/// ```
-pub async fn remove_dir(directory: &str) -> Result<()> {
-    let path = Path::new(directory);
-    let size = path.read_dir()?.count();
-    let read_dir = path.read_dir()?;
-
-    let pb = ProgressBar::new(size.try_into()?);
-    pb.set_style(ProgressStyle::with_template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({per_sec}, {eta})")
-                    .unwrap()
-                    .progress_chars("█  "));
-    pb.set_message(format!("Deleting {}", path.display()));
-
-    let mut removed = 0;
-
-    for entry in read_dir.flatten() {
-        let path = entry.path();
-
-        if path.is_dir() {
-            fs::remove_dir_all(&path).await?;
-        } else {
-            fs::remove_file(&path).await?;
-        }
-        removed += 1;
-        pb.set_position(removed);
-    }
-
-    if let Err(e) = fs::remove_dir(directory).await {
-        return Err(anyhow!("Failed to remove {directory}: {e}"));
-    }
-
-    pb.finish_with_message(format!("Finished removing {}", path.display()));
-
-    Ok(())
-}
 
 /// Asynchronously copies a directory from one location to another.
 ///


### PR DESCRIPTION
closes #389

# Summary

Automatic retry with `make distclean` and faster builds

## Description

The build can sometimes fail due to lack of hermeticity, which `make distclean` resolves by clearing the build and third party deps folders. Thus, whenever the build fails, `make distclean` is called and the build is tried again. There are some errors like the following that can be checked against, but I'm not privy to the exact format so I think a indiscriminate retry is warranted.

```
mkdir -p ".deps"
CMake Error: Error: generator : Ninja
Does not match the generator used previously: Unix Makefiles
Either remove the CMakeCache.txt file and CMakeFiles directory or choose a different binary directory.
make: *** [build/.ran-deps-cmake] Error 1
2026-01-02T10:53:44.855866Z  WARN Make build failed, running make distclean and retrying
```

Additionally, we no longer recreate the build folder as this makes the build times unnecessarily longer with this change.

## Type of change

- [x] - Bug fix (non-breaking change which fixes an issue)

## Checklist

<details>
  <summary>
    Checklist tick-boxes
  </summary>
<p>

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `cargo fmt`
- [x] - No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)

2. Best-Effort

- [x] - My changes generate no new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

3. Documentation

- [x] - Any documentation that relates to this PR has been updated
    or will be updated in a PR (Link here: )(if applicable)

4. Tests

- [x] - I have added tests that prove my fix is effective or that my feature works
- [x] - New and existing unit tests pass locally with my changes

5. Dependencies

- [x] - Any dependent changes have been merged and published in downstream modules

</p>
</details>