### PR TITLE
ci: do not run ci on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
     clippy:
+        if: github.repository == 'MordechaiHadad/bob'
         strategy:
             matrix:
                 os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
@@ -23,6 +24,7 @@ jobs:
                   args: --verbose -- -D warnings
 
     test:
+        if: github.repository == 'MordechaiHadad/bob'
         strategy:
             matrix:
                 os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
@@ -43,6 +45,7 @@ jobs:
                   args: --locked --verbose
 
     formatting:
+        if: github.repository == 'MordechaiHadad/bob'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -60,8 +63,9 @@ jobs:
                   args: --all -- --check --verbose
 
     security_audit:
-      runs-on: ubuntu-latest
-      steps:
+        if: github.repository == 'MordechaiHadad/bob'
+        runs-on: ubuntu-latest
+        steps:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Install toolchain
@@ -82,6 +86,7 @@ jobs:
                   args: --deny warnings
 
     build:
+        if: github.repository == 'MordechaiHadad/bob'
         needs: [clippy, formatting, test, security_audit]
         strategy:
             matrix:


### PR DESCRIPTION
# Summary

prevent ci from running on forks

## Description

it's pretty annoying to have ci running on a fork when it's already running in the main repo, so prevent that from happening
