### PR TITLE
Change: Use checksum for proxy instead of weird flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tar",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",
@@ -535,6 +536,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -1868,6 +1875,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ what-the-path = "^0.1.3"
 sysinfo = "0.35.2"
 clap_complete_nushell = "4.5.8"
 
+[dev-dependencies]
+tempfile = "3"
+
 [dependencies.chrono]
 version = "0.4.23"
 features = ["serde"]

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -170,7 +170,7 @@ pub async fn switch(config: &Config, version: &ParsedVersion) -> Result<()> {
 ///
 /// This function gets the current executable's path, determines the installation directory, creates it if it doesn't exist, adds it to the system's PATH, and copies the current executable to the installation directory as "nvim" or "nvim.exe" (on Windows).
 ///
-/// If a file named "nvim" or "nvim.exe" already exists in the installation directory, the function checks its version. If the version matches the current version, the function does nothing. Otherwise, it replaces the file with the current executable.
+/// If a file named "nvim" or "nvim.exe" already exists in the installation directory, the function compare the checksum. If the checksum matches, the function does nothing. Otherwise, it replaces the file with the current executable.
 ///
 /// # Arguments
 ///

--- a/src/handlers/use_handler.rs
+++ b/src/handlers/use_handler.rs
@@ -3,13 +3,13 @@ use dialoguer::Confirm;
 use reqwest::Client;
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use tokio::fs::{self};
 use tracing::info;
 
 use crate::config::{Config, ConfigFile};
 use crate::handlers::{InstallResult, install_handler};
 use crate::helpers;
+use crate::helpers::checksum::compare_binaries;
 use crate::helpers::directories::get_installation_directory;
 use crate::helpers::version::types::{ParsedVersion, VersionType};
 
@@ -211,16 +211,10 @@ async fn copy_nvim_proxy(config: &ConfigFile) -> Result<()> {
         installation_dir.push("nvim");
     }
 
-    if fs::metadata(&installation_dir).await.is_ok() {
-        let output = Command::new(&installation_dir)
-            .arg("--&bob")
-            .output()?
-            .stdout;
-        let version = String::from_utf8(output)?.trim().to_string();
-
-        if version == env!("CARGO_PKG_VERSION") {
-            return Ok(());
-        }
+    if fs::metadata(&installation_dir).await.is_ok()
+        && compare_binaries(&exe_path, &installation_dir)?
+    {
+        return Ok(());
     }
 
     info!("Updating neovim proxy");

--- a/src/helpers/checksum.rs
+++ b/src/helpers/checksum.rs
@@ -31,3 +31,20 @@ pub fn sha256cmp(a: &Path, b: &Path, filename: &str) -> Result<bool> {
 
     Ok(hash == checksum)
 }
+
+fn hash_binary(path: &Path) -> Result<impl PartialEq> {
+    let mut hasher = Sha256::new();
+    let file = fs::File::open(path)?;
+    let mut reader = io::BufReader::new(file);
+    io::copy(&mut reader, &mut hasher)?;
+
+    let hash = hasher.finalize();
+    Ok(hash)
+}
+
+pub fn compare_binaries(origin: &Path, proxy: &Path) -> Result<bool> {
+    let origin_hash = hash_binary(origin)?;
+    let proxy_hash = hash_binary(proxy)?;
+
+    Ok(origin_hash == proxy_hash)
+}

--- a/src/helpers/checksum.rs
+++ b/src/helpers/checksum.rs
@@ -32,6 +32,16 @@ pub fn sha256cmp(a: &Path, b: &Path, filename: &str) -> Result<bool> {
     Ok(hash == checksum)
 }
 
+/// Computes the SHA-256 checksum of the file at `path`.
+/// # Arguments
+///
+/// * `path` - A reference to a `&Path` representing the file whose checksum will be computed.
+///
+/// # Returns
+///
+/// This function returns a `Result` which on success contains the SHA-256 digest produced by
+/// the `sha2` crate (the concrete digest type returned by `Sha256::finalize()`). If the file
+/// cannot be opened or an I/O error occurs while reading, the function returns `Err(error)`.
 fn hash_binary(path: &Path) -> Result<impl PartialEq> {
     let mut hasher = Sha256::new();
     let file = fs::File::open(path)?;
@@ -42,9 +52,85 @@ fn hash_binary(path: &Path) -> Result<impl PartialEq> {
     Ok(hash)
 }
 
+/// Checks whether the SHA-256 checksum of `origin` matches the checksum of `proxy`.
+/// # Arguments
+///
+/// * `origin` - A reference to a `&Path` for the original binary file.
+/// * `proxy` - A reference to a `&Path` for the binary file to compare against the origin.
+///
+/// # Returns
+///
+/// This function returns a `Result` containing a `bool` which is `true` if the SHA-256 digests
+/// of the two files are identical and `false` otherwise. Any I/O or hashing error encountered
+/// while reading either file is returned as `Err(error)`.
 pub fn compare_binaries(origin: &Path, proxy: &Path) -> Result<bool> {
     let origin_hash = hash_binary(origin)?;
     let proxy_hash = hash_binary(proxy)?;
 
     Ok(origin_hash == proxy_hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::fs;
+    use std::io;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn hash_binary_and_compare_binaries_same() {
+        // create two temp files with identical contents
+        let mut f1 = NamedTempFile::new().unwrap();
+        let mut f2 = NamedTempFile::new().unwrap();
+        write!(f1, "hello world").unwrap();
+        write!(f2, "hello world").unwrap();
+        f1.flush().unwrap();
+        f2.flush().unwrap();
+
+        // hash_binary is private, but unit tests in the same module can call it
+        let h1 = hash_binary(f1.path()).unwrap();
+        let h2 = hash_binary(f2.path()).unwrap();
+        assert!(h1 == h2);
+
+        // compare_binaries should report equality
+        assert!(compare_binaries(f1.path(), f2.path()).unwrap());
+    }
+
+    #[test]
+    fn compare_binaries_different() {
+        let mut f1 = NamedTempFile::new().unwrap();
+        let mut f2 = NamedTempFile::new().unwrap();
+        write!(f1, "a").unwrap();
+        write!(f2, "b").unwrap();
+        f1.flush().unwrap();
+        f2.flush().unwrap();
+
+        assert!(!compare_binaries(f1.path(), f2.path()).unwrap());
+    }
+
+    #[test]
+    fn sha256cmp_with_checksum_file() {
+        // create a data file and write content
+        let mut data = NamedTempFile::new().unwrap();
+        write!(data, "payload").unwrap();
+        data.flush().unwrap();
+
+        // compute hex sha256 of the data file (so we can place it in the checksum file)
+        let mut hasher = Sha256::new();
+        let mut file = fs::File::open(data.path()).unwrap();
+        io::copy(&mut file, &mut hasher).unwrap();
+        let hex = format!("{:x}", hasher.finalize());
+
+        // prepare a checksum file in the format: "<hex>  <filename>"
+        // Use the real filename component so sha256cmp's search-by-filename will match.
+        let filename = data.path().file_name().unwrap().to_str().unwrap();
+        let mut checksum = NamedTempFile::new().unwrap();
+        write!(checksum, "{}  {}", hex, filename).unwrap();
+        checksum.flush().unwrap();
+
+        // sha256cmp reads the checksum file and compares the computed digest of the data file
+        assert!(sha256cmp(data.path(), checksum.path(), filename).unwrap());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,11 +45,6 @@ async fn run() -> Result<()> {
     let rest_args = &args[1..];
 
     if exe_name.eq("nvim") {
-        if !rest_args.is_empty() && rest_args[0].eq("--&bob") {
-            print!("{}", env!("CARGO_PKG_VERSION"));
-            return Ok(());
-        }
-
         handle_nvim_process(&config.config, rest_args).await?;
 
         return Ok(());


### PR DESCRIPTION
# Summary


- Fixes #380 

Using checksum validation instead of weird flag.

## Description

Currently bob is using a hack to validate whenever the proxy is using the latest version of bob, which works but eh, I hate it. Anyway this is using sha-2 in order to compare arrays of u8 checksum of the current running exe and the proxy.

## Type of change

- [x] - New feature (non-breaking change which adds functionality)

## Checklist

<details>
  <summary>
    Checklist tick-boxes
  </summary>
<p>

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `cargo fmt`
- [x] - No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)

2. Best-Effort

- [x] - My changes generate no new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

3. Documentation

- [x] - Any documentation that relates to this PR has been updated
    or will be updated in a PR (Link here: )(if applicable)

4. Tests

- [x] - I have added tests that prove my fix is effective or that my feature works
- [x] - New and existing unit tests pass locally with my changes

5. Dependencies

- [x] - Any dependent changes have been merged and published in downstream modules

</p>
</details>
