### PR TITLE
Correct spelling: "Toogle" to "Toggle"

### DIFF
--- a/src/handlers/uninstall_handler.rs
+++ b/src/handlers/uninstall_handler.rs
@@ -129,7 +129,7 @@ async fn uninstall_selections(client: &Client, config: &Config) -> Result<()> {
     };
 
     let selections = MultiSelect::with_theme(&theme)
-        .with_prompt("Toogle with space the versions you wish to uninstall:")
+        .with_prompt("Toggle with space the versions you wish to uninstall:")
         .items(&installed_versions)
         .interact_on_opt(&Term::stderr())?;
 


### PR DESCRIPTION
# Summary

This PR just fixes the spelling of "Toggle" in the prompt string for the uninstall handler.

## Description

This PR is strictly a 1-character change to line 132 in uninstall_handler.rs, changing "Toogle" to "Toggle". I saw the typo while using 'bob rm' and decided to see how quickly I could submit a small PR to fix the spelling.

## Type of change

- [x] - Bug fix (non-breaking change which fixes an issue)

(Does spelling count as a bug?)

## Checklist

<details>
  <summary>
    Checklist tick-boxes
  </summary>
<p>

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `cargo fmt`
- [x] - No clippy warnings (run `cargo clippy --all-targets -- -D warnings`)

2. Best-Effort

- [x] - My changes generate no new warnings
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

3. Documentation

- [x] - Any documentation that relates to this PR has been updated
    or will be updated in a PR (Link here: )(if applicable)

4. Tests

- [x] - I have added tests that prove my fix is effective or that my feature works
- [x] - New and existing unit tests pass locally with my changes

5. Dependencies

- [x] - Any dependent changes have been merged and published in downstream modules

</p>
</details>
